### PR TITLE
feat: Add security services and DeviceClassifier for unassigned device workflow

### DIFF
--- a/lib/features/scanner/domain/entities/device_category.dart
+++ b/lib/features/scanner/domain/entities/device_category.dart
@@ -1,0 +1,45 @@
+/// Category classification for devices in the unassigned device workflow.
+///
+/// Used to determine how devices should be displayed in the device selector
+/// and what operations are valid for them.
+enum DeviceCategory {
+  /// Placeholder device - has a name but missing MAC or Serial Number.
+  /// These are "designed" in the system but not yet physically deployed.
+  /// Can be assigned scanned data.
+  designed,
+
+  /// Fully configured device - has name, MAC, and Serial Number.
+  /// Can be replaced with new scanned data if needed.
+  assigned,
+
+  /// Auto-discovered device - name matches MAC address or Serial Number.
+  /// These should be hidden from selection as they're temporary records.
+  ephemeral,
+
+  /// Invalid device - missing required name field.
+  /// Should be excluded from selection.
+  invalid,
+}
+
+/// Extension methods for DeviceCategory.
+extension DeviceCategoryX on DeviceCategory {
+  /// Returns true if this category represents a selectable device.
+  bool get isSelectable => this == DeviceCategory.designed || this == DeviceCategory.assigned;
+
+  /// Returns true if this device is a placeholder waiting for assignment.
+  bool get isPlaceholder => this == DeviceCategory.designed;
+
+  /// Returns a human-readable label for UI display.
+  String get displayLabel {
+    switch (this) {
+      case DeviceCategory.designed:
+        return 'Designed';
+      case DeviceCategory.assigned:
+        return 'Assigned';
+      case DeviceCategory.ephemeral:
+        return 'Ephemeral';
+      case DeviceCategory.invalid:
+        return 'Invalid';
+    }
+  }
+}

--- a/lib/features/scanner/domain/services/device_classifier.dart
+++ b/lib/features/scanner/domain/services/device_classifier.dart
@@ -1,0 +1,168 @@
+import 'package:rgnets_fdk/features/devices/domain/entities/device.dart';
+import 'package:rgnets_fdk/features/scanner/data/utils/mac_normalizer.dart';
+import 'package:rgnets_fdk/features/scanner/domain/entities/device_category.dart';
+
+/// Classifies devices for the unassigned device workflow.
+///
+/// This service determines how devices should be categorized and displayed
+/// in the device selector during the registration flow.
+///
+/// Based on ATT-FE-Tool's UnassignedDeviceHandler implementation.
+///
+/// Categories:
+/// - **Designed**: Placeholder devices with a name but missing MAC or Serial.
+/// - **Assigned**: Fully configured devices with name, MAC, and Serial.
+/// - **Ephemeral**: Auto-discovered devices (name matches MAC or Serial).
+/// - **Invalid**: Devices missing required name field.
+class DeviceClassifier {
+  DeviceClassifier._();
+
+  /// Check if a value should be considered a placeholder.
+  ///
+  /// Returns true for:
+  /// - null
+  /// - empty string
+  /// - whitespace only
+  /// - "null" (case insensitive)
+  /// - "placeholder" (case insensitive)
+  static bool isPlaceholderValue(String? value) {
+    if (value == null) return true;
+
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return true;
+
+    final lower = trimmed.toLowerCase();
+    return lower == 'null' || lower == 'placeholder';
+  }
+
+  /// Check if a device has an ephemeral name (auto-discovered).
+  ///
+  /// A device is ephemeral if its name matches its MAC address or serial number,
+  /// indicating it was auto-discovered and hasn't been given a proper name.
+  static bool isEphemeralName(Device device) {
+    final name = device.name.trim();
+    if (name.isEmpty) return false;
+
+    // Check if name matches MAC address
+    final mac = device.macAddress;
+    if (mac != null && mac.isNotEmpty) {
+      try {
+        final normalizedMac = MACNormalizer.tryNormalize(mac);
+        final normalizedName = MACNormalizer.tryNormalize(name);
+        if (normalizedMac != null && normalizedName != null && normalizedMac == normalizedName) {
+          return true;
+        }
+      } catch (_) {
+        // If normalization fails, do a simple comparison
+        final macClean = mac.toUpperCase().replaceAll(RegExp(r'[^0-9A-F]'), '');
+        final nameClean = name.toUpperCase().replaceAll(RegExp(r'[^0-9A-F]'), '');
+        if (macClean.isNotEmpty && macClean == nameClean) {
+          return true;
+        }
+      }
+    }
+
+    // Check if name matches serial number
+    final serial = device.serialNumber;
+    if (serial != null && serial.isNotEmpty) {
+      if (name.toLowerCase().trim() == serial.toLowerCase().trim()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /// Check if a device is "designed" (placeholder waiting for assignment).
+  ///
+  /// A designed device has a proper name but is missing MAC or Serial Number.
+  /// These are placeholders in the system that haven't been physically deployed yet.
+  static bool isDesignedDevice(Device device) {
+    // Must have a name
+    if (device.name.trim().isEmpty) return false;
+
+    // Must not be ephemeral
+    if (isEphemeralName(device)) return false;
+
+    // Check if MAC is missing or placeholder
+    final macMissing = isPlaceholderValue(device.macAddress);
+
+    // Check if Serial is missing or placeholder
+    final serialMissing = isPlaceholderValue(device.serialNumber);
+
+    // Designed if missing MAC OR Serial (or both)
+    return macMissing || serialMissing;
+  }
+
+  /// Check if a device is fully assigned (has all required fields).
+  ///
+  /// A fully assigned device has a name, MAC address, and serial number.
+  /// These devices can be replaced with new scanned data if needed.
+  static bool isFullyAssignedDevice(Device device) {
+    // Must have a name
+    if (device.name.trim().isEmpty) return false;
+
+    // Must not be ephemeral
+    if (isEphemeralName(device)) return false;
+
+    // Must have both MAC and Serial (non-placeholder values)
+    final hasMAC = !isPlaceholderValue(device.macAddress);
+    final hasSerial = !isPlaceholderValue(device.serialNumber);
+
+    return hasMAC && hasSerial;
+  }
+
+  /// Classify a device into a category.
+  ///
+  /// Returns the appropriate [DeviceCategory] based on the device's fields.
+  static DeviceCategory classifyDevice(Device device) {
+    // Check for invalid (no name)
+    if (device.name.trim().isEmpty) {
+      return DeviceCategory.invalid;
+    }
+
+    // Check for ephemeral (auto-discovered)
+    if (isEphemeralName(device)) {
+      return DeviceCategory.ephemeral;
+    }
+
+    // Check for designed (placeholder)
+    if (isDesignedDevice(device)) {
+      return DeviceCategory.designed;
+    }
+
+    // Check for fully assigned
+    if (isFullyAssignedDevice(device)) {
+      return DeviceCategory.assigned;
+    }
+
+    // Fallback to invalid (shouldn't happen with proper data)
+    return DeviceCategory.invalid;
+  }
+
+  /// Filter a list of devices to only include selectable ones.
+  ///
+  /// Returns only devices that are either "designed" or "assigned",
+  /// excluding ephemeral and invalid devices.
+  static List<Device> filterSelectableDevices(List<Device> devices) {
+    return devices.where((device) {
+      final category = classifyDevice(device);
+      return category.isSelectable;
+    }).toList();
+  }
+
+  /// Categorize a list of devices into groups by category.
+  ///
+  /// Returns a map where keys are [DeviceCategory] values and values are
+  /// lists of devices in that category.
+  static Map<DeviceCategory, List<Device>> categorizeDevices(List<Device> devices) {
+    final result = <DeviceCategory, List<Device>>{};
+
+    for (final device in devices) {
+      final category = classifyDevice(device);
+      result.putIfAbsent(category, () => []).add(device);
+    }
+
+    return result;
+  }
+}

--- a/test/features/scanner/domain/services/device_classifier_test.dart
+++ b/test/features/scanner/domain/services/device_classifier_test.dart
@@ -1,0 +1,433 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rgnets_fdk/features/devices/domain/entities/device.dart';
+import 'package:rgnets_fdk/features/scanner/domain/entities/device_category.dart';
+import 'package:rgnets_fdk/features/scanner/domain/services/device_classifier.dart';
+
+void main() {
+  group('DeviceClassifier', () {
+    group('isPlaceholderValue', () {
+      test('should return true for null', () {
+        expect(DeviceClassifier.isPlaceholderValue(null), isTrue);
+      });
+
+      test('should return true for empty string', () {
+        expect(DeviceClassifier.isPlaceholderValue(''), isTrue);
+      });
+
+      test('should return true for whitespace only', () {
+        expect(DeviceClassifier.isPlaceholderValue('   '), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue('\t'), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue('\n'), isTrue);
+      });
+
+      test('should return true for "null" string (case insensitive)', () {
+        expect(DeviceClassifier.isPlaceholderValue('null'), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue('NULL'), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue('Null'), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue('nUlL'), isTrue);
+      });
+
+      test('should return true for "placeholder" string (case insensitive)', () {
+        expect(DeviceClassifier.isPlaceholderValue('placeholder'), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue('PLACEHOLDER'), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue('Placeholder'), isTrue);
+      });
+
+      test('should return false for actual values', () {
+        expect(DeviceClassifier.isPlaceholderValue('AA:BB:CC:DD:EE:FF'), isFalse);
+        expect(DeviceClassifier.isPlaceholderValue('SN12345'), isFalse);
+        expect(DeviceClassifier.isPlaceholderValue('some-value'), isFalse);
+      });
+
+      test('should handle whitespace around placeholder values', () {
+        expect(DeviceClassifier.isPlaceholderValue('  null  '), isTrue);
+        expect(DeviceClassifier.isPlaceholderValue(' placeholder '), isTrue);
+      });
+    });
+
+    group('isEphemeralName', () {
+      test('should return false for device with empty name', () {
+        final device = _createDevice(name: '', macAddress: 'AA:BB:CC:DD:EE:FF');
+        expect(DeviceClassifier.isEphemeralName(device), isFalse);
+      });
+
+      test('should return true when name matches normalized MAC (uppercase)', () {
+        final device = _createDevice(
+          name: 'AABBCCDDEEFF',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        expect(DeviceClassifier.isEphemeralName(device), isTrue);
+      });
+
+      test('should return true when name matches MAC with different format', () {
+        final device = _createDevice(
+          name: 'AA:BB:CC:DD:EE:FF',
+          macAddress: 'AABBCCDDEEFF',
+        );
+        expect(DeviceClassifier.isEphemeralName(device), isTrue);
+      });
+
+      test('should return true when name matches MAC case-insensitively', () {
+        final device = _createDevice(
+          name: 'aabbccddeeff',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        expect(DeviceClassifier.isEphemeralName(device), isTrue);
+      });
+
+      test('should return true when name matches serial number', () {
+        final device = _createDevice(
+          name: 'SN12345',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isEphemeralName(device), isTrue);
+      });
+
+      test('should return true when name matches serial (case insensitive)', () {
+        final device = _createDevice(
+          name: 'sn12345',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isEphemeralName(device), isTrue);
+      });
+
+      test('should return false when name is different from MAC and serial', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isEphemeralName(device), isFalse);
+      });
+
+      test('should return false when MAC and serial are both null', () {
+        final device = _createDevice(name: 'Living Room AP');
+        expect(DeviceClassifier.isEphemeralName(device), isFalse);
+      });
+    });
+
+    group('isDesignedDevice', () {
+      test('should return false for device without name', () {
+        final device = _createDevice(name: '');
+        expect(DeviceClassifier.isDesignedDevice(device), isFalse);
+      });
+
+      test('should return false for device with ephemeral name', () {
+        final device = _createDevice(
+          name: 'AABBCCDDEEFF',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        expect(DeviceClassifier.isDesignedDevice(device), isFalse);
+      });
+
+      test('should return true for device with name but missing MAC', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: null,
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isDesignedDevice(device), isTrue);
+      });
+
+      test('should return true for device with name but missing serial', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: null,
+        );
+        expect(DeviceClassifier.isDesignedDevice(device), isTrue);
+      });
+
+      test('should return true for device with name but both MAC and serial missing', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: null,
+          serialNumber: null,
+        );
+        expect(DeviceClassifier.isDesignedDevice(device), isTrue);
+      });
+
+      test('should return true for device with placeholder MAC', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'placeholder',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isDesignedDevice(device), isTrue);
+      });
+
+      test('should return true for device with placeholder serial', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'null',
+        );
+        expect(DeviceClassifier.isDesignedDevice(device), isTrue);
+      });
+
+      test('should return false for fully assigned device', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isDesignedDevice(device), isFalse);
+      });
+    });
+
+    group('isFullyAssignedDevice', () {
+      test('should return false for device without name', () {
+        final device = _createDevice(
+          name: '',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isFullyAssignedDevice(device), isFalse);
+      });
+
+      test('should return false for device with ephemeral name', () {
+        final device = _createDevice(
+          name: 'AABBCCDDEEFF',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isFullyAssignedDevice(device), isFalse);
+      });
+
+      test('should return false for device missing MAC', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: null,
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isFullyAssignedDevice(device), isFalse);
+      });
+
+      test('should return false for device missing serial', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: null,
+        );
+        expect(DeviceClassifier.isFullyAssignedDevice(device), isFalse);
+      });
+
+      test('should return false for device with placeholder MAC', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'placeholder',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isFullyAssignedDevice(device), isFalse);
+      });
+
+      test('should return false for device with placeholder serial', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'NULL',
+        );
+        expect(DeviceClassifier.isFullyAssignedDevice(device), isFalse);
+      });
+
+      test('should return true for device with name, MAC, and serial all present', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.isFullyAssignedDevice(device), isTrue);
+      });
+    });
+
+    group('classifyDevice', () {
+      test('should return invalid for device without name', () {
+        final device = _createDevice(name: '');
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.invalid);
+      });
+
+      test('should return ephemeral for device with name matching MAC', () {
+        final device = _createDevice(
+          name: 'AABBCCDDEEFF',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.ephemeral);
+      });
+
+      test('should return ephemeral for device with name matching serial', () {
+        final device = _createDevice(
+          name: 'SN12345',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.ephemeral);
+      });
+
+      test('should return designed for device with name but missing MAC', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: null,
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.designed);
+      });
+
+      test('should return designed for device with name but missing serial', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: null,
+        );
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.designed);
+      });
+
+      test('should return designed for device with placeholder values', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'placeholder',
+          serialNumber: 'null',
+        );
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.designed);
+      });
+
+      test('should return assigned for fully configured device', () {
+        final device = _createDevice(
+          name: 'Living Room AP',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          serialNumber: 'SN12345',
+        );
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.assigned);
+      });
+    });
+
+    group('filterSelectableDevices', () {
+      test('should exclude ephemeral devices', () {
+        final devices = [
+          _createDevice(name: 'AABBCCDDEEFF', macAddress: 'AA:BB:CC:DD:EE:FF'), // ephemeral
+          _createDevice(name: 'Living Room AP', macAddress: null), // designed
+          _createDevice(name: 'Kitchen AP', macAddress: 'BB:CC:DD:EE:FF:00', serialNumber: 'SN999'), // assigned
+        ];
+
+        final result = DeviceClassifier.filterSelectableDevices(devices);
+        expect(result.length, equals(2));
+        expect(result.any((d) => d.name == 'Living Room AP'), isTrue);
+        expect(result.any((d) => d.name == 'Kitchen AP'), isTrue);
+      });
+
+      test('should exclude invalid devices (no name)', () {
+        final devices = [
+          _createDevice(name: '', macAddress: 'AA:BB:CC:DD:EE:FF'), // invalid
+          _createDevice(name: 'Living Room AP', macAddress: null), // designed
+        ];
+
+        final result = DeviceClassifier.filterSelectableDevices(devices);
+        expect(result.length, equals(1));
+        expect(result.first.name, equals('Living Room AP'));
+      });
+
+      test('should return both designed and assigned devices', () {
+        final devices = [
+          _createDevice(name: 'Designed AP', macAddress: null, serialNumber: null),
+          _createDevice(name: 'Assigned AP', macAddress: 'AA:BB:CC:DD:EE:FF', serialNumber: 'SN123'),
+        ];
+
+        final result = DeviceClassifier.filterSelectableDevices(devices);
+        expect(result.length, equals(2));
+      });
+
+      test('should return empty list for empty input', () {
+        final result = DeviceClassifier.filterSelectableDevices([]);
+        expect(result, isEmpty);
+      });
+    });
+
+    group('categorizeDevices', () {
+      test('should correctly categorize mixed device list', () {
+        final devices = [
+          _createDevice(name: 'AABBCCDDEEFF', macAddress: 'AA:BB:CC:DD:EE:FF'), // ephemeral
+          _createDevice(name: 'Designed 1', macAddress: null), // designed
+          _createDevice(name: 'Designed 2', serialNumber: 'placeholder'), // designed
+          _createDevice(name: 'Assigned 1', macAddress: 'BB:CC:DD:EE:FF:00', serialNumber: 'SN1'), // assigned
+          _createDevice(name: '', macAddress: 'CC:DD:EE:FF:00:11'), // invalid
+        ];
+
+        final result = DeviceClassifier.categorizeDevices(devices);
+
+        expect(result[DeviceCategory.ephemeral]?.length, equals(1));
+        expect(result[DeviceCategory.designed]?.length, equals(2));
+        expect(result[DeviceCategory.assigned]?.length, equals(1));
+        expect(result[DeviceCategory.invalid]?.length, equals(1));
+      });
+
+      test('should return empty map for empty input', () {
+        final result = DeviceClassifier.categorizeDevices([]);
+        expect(result, isEmpty);
+      });
+    });
+
+    group('edge cases', () {
+      test('should handle device with all null optional fields', () {
+        final device = _createDevice(
+          name: 'Test AP',
+          macAddress: null,
+          serialNumber: null,
+        );
+        expect(DeviceClassifier.classifyDevice(device), DeviceCategory.designed);
+      });
+
+      test('should handle device with empty strings vs null', () {
+        final deviceEmpty = _createDevice(
+          name: 'Test AP',
+          macAddress: '',
+          serialNumber: '',
+        );
+        final deviceNull = _createDevice(
+          name: 'Test AP',
+          macAddress: null,
+          serialNumber: null,
+        );
+
+        // Both should be classified as designed
+        expect(DeviceClassifier.classifyDevice(deviceEmpty), DeviceCategory.designed);
+        expect(DeviceClassifier.classifyDevice(deviceNull), DeviceCategory.designed);
+      });
+
+      test('should handle MAC address formats in ephemeral detection', () {
+        // Various MAC formats should all be detected as ephemeral
+        final devices = [
+          _createDevice(name: 'AA-BB-CC-DD-EE-FF', macAddress: 'AA:BB:CC:DD:EE:FF'),
+          _createDevice(name: 'aa:bb:cc:dd:ee:ff', macAddress: 'AABBCCDDEEFF'),
+          _createDevice(name: 'aabb.ccdd.eeff', macAddress: 'AA:BB:CC:DD:EE:FF'),
+        ];
+
+        for (final device in devices) {
+          expect(
+            DeviceClassifier.isEphemeralName(device),
+            isTrue,
+            reason: 'Device with name "${device.name}" should be ephemeral',
+          );
+        }
+      });
+    });
+  });
+}
+
+/// Helper function to create a Device for testing.
+Device _createDevice({
+  required String name,
+  String? macAddress,
+  String? serialNumber,
+  String id = '1',
+  String type = 'access_point',
+  String status = 'online',
+}) {
+  return Device(
+    id: id,
+    name: name,
+    type: type,
+    status: status,
+    macAddress: macAddress,
+    serialNumber: serialNumber,
+  );
+}


### PR DESCRIPTION
## Summary

- Add security infrastructure services (SafeCache, ActionCable, CertificateValidator)
- Implement DeviceClassifier for unassigned device workflow from ATT-FE-Tool reference

## Changes

### Security Services
- **SafeCache**: Type-safe request deduplication for concurrent async operations
- **ActionCable**: Rails WebSocket protocol implementation with channel subscriptions and event bus
- **CertificateValidator**: SSL/TLS certificate validation with self-signed detection

### DeviceClassifier (Unassigned Device Workflow)
- **DeviceCategory enum**: designed, assigned, ephemeral, invalid categories
- **DeviceClassifier service**:
  - Placeholder detection (null, empty, 'null', 'placeholder')
  - Ephemeral name detection (auto-discovered devices where name matches MAC/serial)
  - Device classification for registration UI
- **Updated scanner_registration_popup.dart** to use DeviceClassifier instead of inline methods

## Test Plan

- [x] 85 tests for security services (SafeCache, ActionCable, CertificateValidator)
- [x] 46 tests for DeviceClassifier
- [x] All 131 tests passing

## Files Changed

### New Files
- `lib/core/services/safe_cache.dart`
- `lib/core/services/action_cable_service.dart`
- `lib/features/scanner/domain/entities/device_category.dart`
- `lib/features/scanner/domain/services/device_classifier.dart`
- `test/core/services/safe_cache_test.dart`
- `test/core/services/action_cable_service_test.dart`
- `test/core/security/certificate_validator_test.dart`
- `test/features/scanner/domain/services/device_classifier_test.dart`

### Modified Files
- `lib/features/scanner/presentation/widgets/scanner_registration_popup.dart`

🤖 Generated with [Claude Code](https://claude.ai/code)