### PR TITLE
feat: add room filter, fix device notes, add reboot button

### DIFF
--- a/lib/core/services/storage_service.dart
+++ b/lib/core/services/storage_service.dart
@@ -25,12 +25,16 @@ class StorageService {
   static const String _keySyncInterval = 'sync_interval';
   static const String _keyPhaseFilter = 'device_phase_filter';
   static const String _keyStatusFilter = 'device_status_filter';
+  static const String _keyRoomFilter = 'device_room_filter';
 
   /// Public key for phase filter (for tests and direct access)
   static const String keyPhaseFilter = _keyPhaseFilter;
 
   /// Public key for status filter (for tests and direct access)
   static const String keyStatusFilter = _keyStatusFilter;
+
+  /// Public key for room filter (for tests and direct access)
+  static const String keyRoomFilter = _keyRoomFilter;
 
   // Legacy keys for migration
   static const String _legacyKeyApiUrl = 'api_url';
@@ -231,6 +235,12 @@ class StorageService {
   Future<void> setStatusFilter(String status) =>
       _prefs.setString(_keyStatusFilter, status);
   Future<void> clearStatusFilter() => _prefs.remove(_keyStatusFilter);
+
+  // Room filter
+  String? get roomFilter => _prefs.getString(_keyRoomFilter);
+  Future<void> setRoomFilter(String room) =>
+      _prefs.setString(_keyRoomFilter, room);
+  Future<void> clearRoomFilter() => _prefs.remove(_keyRoomFilter);
 
   // Generic methods
   Future<bool> setBool(String key, {required bool value}) =>

--- a/lib/features/devices/data/datasources/device_data_source.dart
+++ b/lib/features/devices/data/datasources/device_data_source.dart
@@ -26,6 +26,10 @@ abstract class DeviceDataSource {
   /// Updates a device
   Future<DeviceModelSealed> updateDevice(DeviceModelSealed device);
 
+  /// Updates only the device note field
+  /// This sends only the note to the backend, avoiding issues with full device serialization
+  Future<DeviceModelSealed> updateDeviceNote(String deviceId, String? note);
+
   /// Reboots a device
   Future<void> rebootDevice(String deviceId);
 

--- a/lib/features/devices/data/datasources/device_mock_data_source.dart
+++ b/lib/features/devices/data/datasources/device_mock_data_source.dart
@@ -113,6 +113,18 @@ class DeviceMockDataSourceImpl implements DeviceDataSource {
   }
 
   @override
+  Future<DeviceModelSealed> updateDeviceNote(String deviceId, String? note) async {
+    // Get the device and return a copy with the updated note
+    final device = await getDevice(deviceId);
+    return device.map(
+      ap: (d) => d.copyWith(note: note),
+      ont: (d) => d.copyWith(note: note),
+      switchDevice: (d) => d.copyWith(note: note),
+      wlan: (d) => d.copyWith(note: note),
+    );
+  }
+
+  @override
   Future<void> rebootDevice(String deviceId) async {
     // Mock reboot - just verify device exists
     await getDevice(deviceId);

--- a/lib/features/devices/data/repositories/device_repository.dart
+++ b/lib/features/devices/data/repositories/device_repository.dart
@@ -455,6 +455,20 @@ class DeviceRepositoryImpl implements DeviceRepository {
     }
   }
 
+  @override
+  Future<Either<Failure, Device>> updateDeviceNote(String deviceId, String? note) async {
+    try {
+      if (!_isAuthenticated()) {
+        return const Left(DeviceFailure(message: 'Not authenticated'));
+      }
+      final updatedModel = await dataSource.updateDeviceNote(deviceId, note);
+      await _cacheDeviceToTypedCache(updatedModel);
+      return Right(updatedModel.toEntity());
+    } on Exception catch (e) {
+      return Left(DeviceFailure(message: 'Failed to update note: $e'));
+    }
+  }
+
   /// Convert a Device entity to the appropriate DeviceModelSealed variant
   DeviceModelSealed _deviceToSealedModel(Device device) {
     switch (device.type) {

--- a/lib/features/devices/domain/repositories/device_repository.dart
+++ b/lib/features/devices/domain/repositories/device_repository.dart
@@ -15,6 +15,7 @@ abstract class DeviceRepository {
   Future<Either<Failure, List<Device>>> getDevicesByRoom(String roomId);
   Future<Either<Failure, List<Device>>> searchDevices(String query);
   Future<Either<Failure, Device>> updateDevice(Device device);
+  Future<Either<Failure, Device>> updateDeviceNote(String deviceId, String? note);
   Future<Either<Failure, void>> rebootDevice(String deviceId);
   Future<Either<Failure, void>> resetDevice(String deviceId);
   Future<Either<Failure, Device>> deleteDeviceImage(

--- a/lib/features/devices/presentation/providers/device_ui_state_provider.g.dart
+++ b/lib/features/devices/presentation/providers/device_ui_state_provider.g.dart
@@ -7,7 +7,7 @@ part of 'device_ui_state_provider.dart';
 // **************************************************************************
 
 String _$filteredDevicesListHash() =>
-    r'2dca6d28ecb2baf5382d3fc34ebb6c5317700f7b';
+    r'a0ec282ba7d03e362d01b4b38a35e5bef5930b3f';
 
 /// Provider for filtered devices based on UI state
 ///
@@ -75,7 +75,7 @@ final devicePhasesProvider = AutoDisposeProvider<List<String>>.internal(
 
 typedef DevicePhasesRef = AutoDisposeProviderRef<List<String>>;
 String _$deviceUIStateNotifierHash() =>
-    r'a0cd0c8b76e6af29108a1f7dc89277de59f50758';
+    r'bea11b3117b1442305ef258a9df2f6dfd4b50a6d';
 
 /// Provider for device UI state (search, filters, etc.)
 ///

--- a/lib/features/devices/presentation/providers/devices_provider.dart
+++ b/lib/features/devices/presentation/providers/devices_provider.dart
@@ -433,6 +433,7 @@ class DeviceNotifier extends _$DeviceNotifier {
   }
 
   /// Updates the device note via WebSocket
+  /// Uses dedicated updateDeviceNote method that only sends the note field
   Future<bool> updateNote(String note) async {
     final currentDevice = state.valueOrNull;
     if (currentDevice == null) {
@@ -442,9 +443,12 @@ class DeviceNotifier extends _$DeviceNotifier {
 
     try {
       final repository = ref.read(deviceRepositoryProvider);
-      // Create updated device with new note
-      final updatedDevice = currentDevice.copyWith(note: note.isEmpty ? null : note);
-      final result = await repository.updateDevice(updatedDevice);
+      // Use dedicated note update method that only sends the note field
+      // Pass empty string directly to clear the note on the backend
+      final result = await repository.updateDeviceNote(
+        deviceId,
+        note,
+      );
 
       return result.fold(
         (failure) {

--- a/lib/features/devices/presentation/providers/devices_provider.g.dart
+++ b/lib/features/devices/presentation/providers/devices_provider.g.dart
@@ -22,7 +22,7 @@ final devicesNotifierProvider =
 );
 
 typedef _$DevicesNotifier = AsyncNotifier<List<Device>>;
-String _$deviceNotifierHash() => r'46818e2910dc06852fcac29e0ef4473d423c34f0';
+String _$deviceNotifierHash() => r'cf3ebe7c65173144858d1bc65dd476c168fe7a26';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/features/devices/presentation/providers/room_filter_provider.dart
+++ b/lib/features/devices/presentation/providers/room_filter_provider.dart
@@ -1,0 +1,128 @@
+import 'package:rgnets_fdk/core/providers/core_providers.dart';
+import 'package:rgnets_fdk/core/services/storage_service.dart';
+import 'package:rgnets_fdk/features/rooms/presentation/providers/rooms_riverpod_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'room_filter_provider.g.dart';
+
+/// State for device room filtering
+class RoomFilterState {
+  const RoomFilterState({this.selectedRoom = allRooms});
+
+  /// Special value indicating no filter (show all rooms)
+  static const String allRooms = 'All Rooms';
+
+  /// Currently selected room filter
+  final String selectedRoom;
+
+  /// Returns true if actively filtering (not showing all)
+  bool get isFiltering => selectedRoom != allRooms;
+
+  /// Check if a device's room matches the current filter
+  bool matchesFilter(String? deviceRoom) {
+    if (!isFiltering) {
+      return true; // Show all when not filtering
+    }
+
+    if (deviceRoom == null || deviceRoom.trim().isEmpty) {
+      return false; // No match for null/empty room when filtering
+    }
+
+    return deviceRoom.trim().toLowerCase() == selectedRoom.toLowerCase();
+  }
+
+  /// Create a copy with updated values
+  RoomFilterState copyWith({String? selectedRoom}) {
+    return RoomFilterState(
+      selectedRoom: selectedRoom ?? this.selectedRoom,
+    );
+  }
+
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoomFilterState &&
+          runtimeType == other.runtimeType &&
+          selectedRoom == other.selectedRoom;
+
+  @override
+  int get hashCode => selectedRoom.hashCode;
+}
+
+/// Notifier for managing room filter state with persistence
+@riverpod
+class RoomFilterNotifier extends _$RoomFilterNotifier {
+  StorageService? _storageService;
+
+  @override
+  RoomFilterState build() {
+    // Try to get storage service from provider
+    try {
+      _storageService = ref.watch(storageServiceProvider);
+    } on Object {
+      // Storage service not available yet (e.g., during tests without override)
+      _storageService = null;
+    }
+
+    // Load saved room synchronously from storage
+    final savedRoom = _storageService?.roomFilter;
+    if (savedRoom != null && savedRoom.isNotEmpty) {
+      return RoomFilterState(selectedRoom: savedRoom);
+    }
+    return const RoomFilterState();
+  }
+
+  /// Set the selected room filter
+  void setRoom(String room) {
+    if (state.selectedRoom == room) {
+      return;
+    }
+    state = state.copyWith(selectedRoom: room);
+    _saveRoom(room);
+  }
+
+  /// Clear the filter (set to All Rooms)
+  void clear() {
+    setRoom(RoomFilterState.allRooms);
+  }
+
+  /// Save current room to storage
+  Future<void> _saveRoom(String room) async {
+    if (_storageService == null) {
+      return;
+    }
+    if (room == RoomFilterState.allRooms) {
+      // Remove the key when showing all rooms
+      await _storageService!.clearRoomFilter();
+    } else {
+      await _storageService!.setRoomFilter(room);
+    }
+  }
+}
+
+/// Provider for available rooms based on rooms data (not devices)
+@riverpod
+List<String> deviceRooms(DeviceRoomsRef ref) {
+  final rooms = ref.watch(roomsNotifierProvider);
+
+  return rooms.when(
+    data: (roomList) {
+      if (roomList.isEmpty) {
+        return [RoomFilterState.allRooms];
+      }
+
+      // Extract room names, trimmed and sorted alphabetically
+      final roomNames = roomList
+          .map((room) => room.name.trim())
+          .where((name) => name.isNotEmpty)
+          .toSet()
+          .toList()
+        ..sort();
+
+      return [RoomFilterState.allRooms, ...roomNames];
+    },
+    loading: () => [RoomFilterState.allRooms],
+    error: (_, __) => [RoomFilterState.allRooms],
+  );
+}

--- a/lib/features/devices/presentation/providers/room_filter_provider.g.dart
+++ b/lib/features/devices/presentation/providers/room_filter_provider.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'room_filter_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$deviceRoomsHash() => r'08138c439dc565738a0e6be8ed04001124c338da';
+
+/// Provider for available rooms based on rooms data (not devices)
+///
+/// Copied from [deviceRooms].
+@ProviderFor(deviceRooms)
+final deviceRoomsProvider = AutoDisposeProvider<List<String>>.internal(
+  deviceRooms,
+  name: r'deviceRoomsProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$deviceRoomsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef DeviceRoomsRef = AutoDisposeProviderRef<List<String>>;
+String _$roomFilterNotifierHash() =>
+    r'b8a6ed24b4cbca068f5850a400bdf54c03862776';
+
+/// Notifier for managing room filter state with persistence
+///
+/// Copied from [RoomFilterNotifier].
+@ProviderFor(RoomFilterNotifier)
+final roomFilterNotifierProvider =
+    AutoDisposeNotifierProvider<RoomFilterNotifier, RoomFilterState>.internal(
+  RoomFilterNotifier.new,
+  name: r'roomFilterNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$roomFilterNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$RoomFilterNotifier = AutoDisposeNotifier<RoomFilterState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/features/devices/presentation/screens/device_detail_screen.dart
+++ b/lib/features/devices/presentation/screens/device_detail_screen.dart
@@ -149,8 +149,8 @@ class _DeviceDetailScreenState extends ConsumerState<DeviceDetailScreen>
       case 'locate':
         _locateDevice(device);
         break;
-      case 'support':
-        _openSupport(device);
+      case 'reboot':
+        _rebootDevice(device);
         break;
     }
   }
@@ -175,10 +175,69 @@ class _DeviceDetailScreenState extends ConsumerState<DeviceDetailScreen>
     );
   }
   
-  void _openSupport(Device device) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Opening support for ${device.name}')),
-    );
+  void _rebootDevice(Device device) {
+    showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Reboot Device'),
+        content: Text('Are you sure you want to reboot ${device.name}?\n\nThe device will be temporarily unavailable.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: TextButton.styleFrom(foregroundColor: Colors.orange),
+            child: const Text('Reboot'),
+          ),
+        ],
+      ),
+    ).then((confirmed) async {
+      if ((confirmed ?? false) && mounted) {
+        // Show loading indicator
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Row(
+              children: [
+                const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 16),
+                Text('Rebooting ${device.name}...'),
+              ],
+            ),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+
+        try {
+          await ref
+              .read(devicesNotifierProvider.notifier)
+              .rebootDevice(device.id);
+
+          if (!mounted) return;
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Reboot command sent to ${device.name}'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        } on Exception catch (e) {
+          if (!mounted) return;
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Failed to reboot: $e'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    });
   }
 }
 
@@ -791,9 +850,9 @@ class _QuickActionsBar extends StatelessWidget {
                 onTap: () => onAction('locate', device),
               ),
               _QuickActionButton(
-                icon: Icons.support,
-                label: 'Support',
-                onTap: () => onAction('support', device),
+                icon: Icons.restart_alt,
+                label: 'Reboot',
+                onTap: () => onAction('reboot', device),
               ),
             ],
           ),

--- a/lib/features/rooms/presentation/screens/rooms_screen.dart
+++ b/lib/features/rooms/presentation/screens/rooms_screen.dart
@@ -72,10 +72,7 @@ class _RoomsScreenState extends ConsumerState<RoomsScreen> {
               ),
             ),
             data: (_) {
-          
-              return RefreshIndicator(
-                onRefresh: () => ref.read(roomsNotifierProvider.notifier).refresh(),
-            child: Column(
+              return Column(
               children: [
                 // Search bar
                 SearchBarWidget(
@@ -209,9 +206,8 @@ class _RoomsScreenState extends ConsumerState<RoomsScreen> {
                         );
                   }(),
                 ),
-                ],
-                ),
-              );
+              ],
+            );
             },
           );
         },


### PR DESCRIPTION
## Summary

- **Room filter for devices view**: Adds a room filter dropdown to the devices view filter bar. Uses `roomsNotifierProvider` for a reliable room list and matches devices by `pmsRoomId` for accuracy. Filter selection is persisted to storage.

- **Fix technician notes not saving**: Adds dedicated `updateDeviceNote` method that sends only the note field, preventing invalid `device_type` field from causing 500 errors.

- **Add reboot device button**: Replaces the support button in device detail screen's bottom bar with a reboot button. Includes confirmation dialog before restart.

- **Remove pull-to-refresh from locations view**: Removes RefreshIndicator from rooms_screen.dart.

## Test plan

- [x] Verify room filter dropdown appears in devices view
- [x] Select a room and verify only devices in that room are shown
- [x] Select "All Rooms" and verify all devices are shown
- [ ] Verify room filter persists after app restart
- [x] Edit a device note and verify it saves to backend
- [x] Clear a device note and verify it clears on backend
- [x] Tap reboot button on device detail screen
- [x] Verify confirmation dialog appears before reboot
- [ ] Verify locations screen no longer has pull-to-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)