### PR TITLE
feat: API key revocation handling and alert navigation

### DIFF
--- a/lib/core/models/api_key_revocation_event.dart
+++ b/lib/core/models/api_key_revocation_event.dart
@@ -1,0 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'api_key_revocation_event.freezed.dart';
+part 'api_key_revocation_event.g.dart';
+
+/// Represents an API key revocation event received from the server.
+///
+/// This event is sent when:
+/// - A new API key is generated (revoking the old one)
+/// - An API key is explicitly deleted
+/// - An API key expires
+/// - A security-triggered revocation occurs
+@freezed
+class ApiKeyRevocationEvent with _$ApiKeyRevocationEvent {
+  const factory ApiKeyRevocationEvent({
+    /// The reason for revocation (e.g., 'new_key_generated', 'key_deleted', 'key_expired', 'security_revocation')
+    required String reason,
+
+    /// User-facing message explaining the revocation
+    String? message,
+
+    /// Timestamp when the revocation occurred
+    DateTime? timestamp,
+  }) = _ApiKeyRevocationEvent;
+
+  factory ApiKeyRevocationEvent.fromJson(Map<String, dynamic> json) =>
+      _$ApiKeyRevocationEventFromJson(json);
+}

--- a/lib/core/models/api_key_revocation_event.freezed.dart
+++ b/lib/core/models/api_key_revocation_event.freezed.dart
@@ -1,0 +1,302 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'api_key_revocation_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ApiKeyRevocationEvent _$ApiKeyRevocationEventFromJson(
+    Map<String, dynamic> json) {
+  return _ApiKeyRevocationEvent.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ApiKeyRevocationEvent {
+  /// The reason for revocation (e.g., 'new_key_generated', 'key_deleted', 'key_expired', 'security_revocation')
+  String get reason => throw _privateConstructorUsedError;
+
+  /// User-facing message explaining the revocation
+  String? get message => throw _privateConstructorUsedError;
+
+  /// Timestamp when the revocation occurred
+  DateTime? get timestamp => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String reason, String? message, DateTime? timestamp)
+        $default,
+  ) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String reason, String? message, DateTime? timestamp)?
+        $default,
+  ) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String reason, String? message, DateTime? timestamp)?
+        $default, {
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ApiKeyRevocationEvent value) $default,
+  ) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ApiKeyRevocationEvent value)? $default,
+  ) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ApiKeyRevocationEvent value)? $default, {
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ApiKeyRevocationEventCopyWith<ApiKeyRevocationEvent> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ApiKeyRevocationEventCopyWith<$Res> {
+  factory $ApiKeyRevocationEventCopyWith(ApiKeyRevocationEvent value,
+          $Res Function(ApiKeyRevocationEvent) then) =
+      _$ApiKeyRevocationEventCopyWithImpl<$Res, ApiKeyRevocationEvent>;
+  @useResult
+  $Res call({String reason, String? message, DateTime? timestamp});
+}
+
+/// @nodoc
+class _$ApiKeyRevocationEventCopyWithImpl<$Res,
+        $Val extends ApiKeyRevocationEvent>
+    implements $ApiKeyRevocationEventCopyWith<$Res> {
+  _$ApiKeyRevocationEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reason = null,
+    Object? message = freezed,
+    Object? timestamp = freezed,
+  }) {
+    return _then(_value.copyWith(
+      reason: null == reason
+          ? _value.reason
+          : reason // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timestamp: freezed == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ApiKeyRevocationEventImplCopyWith<$Res>
+    implements $ApiKeyRevocationEventCopyWith<$Res> {
+  factory _$$ApiKeyRevocationEventImplCopyWith(
+          _$ApiKeyRevocationEventImpl value,
+          $Res Function(_$ApiKeyRevocationEventImpl) then) =
+      __$$ApiKeyRevocationEventImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String reason, String? message, DateTime? timestamp});
+}
+
+/// @nodoc
+class __$$ApiKeyRevocationEventImplCopyWithImpl<$Res>
+    extends _$ApiKeyRevocationEventCopyWithImpl<$Res,
+        _$ApiKeyRevocationEventImpl>
+    implements _$$ApiKeyRevocationEventImplCopyWith<$Res> {
+  __$$ApiKeyRevocationEventImplCopyWithImpl(_$ApiKeyRevocationEventImpl _value,
+      $Res Function(_$ApiKeyRevocationEventImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reason = null,
+    Object? message = freezed,
+    Object? timestamp = freezed,
+  }) {
+    return _then(_$ApiKeyRevocationEventImpl(
+      reason: null == reason
+          ? _value.reason
+          : reason // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      timestamp: freezed == timestamp
+          ? _value.timestamp
+          : timestamp // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ApiKeyRevocationEventImpl implements _ApiKeyRevocationEvent {
+  const _$ApiKeyRevocationEventImpl(
+      {required this.reason, this.message, this.timestamp});
+
+  factory _$ApiKeyRevocationEventImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ApiKeyRevocationEventImplFromJson(json);
+
+  /// The reason for revocation (e.g., 'new_key_generated', 'key_deleted', 'key_expired', 'security_revocation')
+  @override
+  final String reason;
+
+  /// User-facing message explaining the revocation
+  @override
+  final String? message;
+
+  /// Timestamp when the revocation occurred
+  @override
+  final DateTime? timestamp;
+
+  @override
+  String toString() {
+    return 'ApiKeyRevocationEvent(reason: $reason, message: $message, timestamp: $timestamp)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ApiKeyRevocationEventImpl &&
+            (identical(other.reason, reason) || other.reason == reason) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.timestamp, timestamp) ||
+                other.timestamp == timestamp));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, reason, message, timestamp);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ApiKeyRevocationEventImplCopyWith<_$ApiKeyRevocationEventImpl>
+      get copyWith => __$$ApiKeyRevocationEventImplCopyWithImpl<
+          _$ApiKeyRevocationEventImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String reason, String? message, DateTime? timestamp)
+        $default,
+  ) {
+    return $default(reason, message, timestamp);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String reason, String? message, DateTime? timestamp)?
+        $default,
+  ) {
+    return $default?.call(reason, message, timestamp);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String reason, String? message, DateTime? timestamp)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(reason, message, timestamp);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ApiKeyRevocationEvent value) $default,
+  ) {
+    return $default(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ApiKeyRevocationEvent value)? $default,
+  ) {
+    return $default?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ApiKeyRevocationEvent value)? $default, {
+    required TResult orElse(),
+  }) {
+    if ($default != null) {
+      return $default(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ApiKeyRevocationEventImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ApiKeyRevocationEvent implements ApiKeyRevocationEvent {
+  const factory _ApiKeyRevocationEvent(
+      {required final String reason,
+      final String? message,
+      final DateTime? timestamp}) = _$ApiKeyRevocationEventImpl;
+
+  factory _ApiKeyRevocationEvent.fromJson(Map<String, dynamic> json) =
+      _$ApiKeyRevocationEventImpl.fromJson;
+
+  @override
+
+  /// The reason for revocation (e.g., 'new_key_generated', 'key_deleted', 'key_expired', 'security_revocation')
+  String get reason;
+  @override
+
+  /// User-facing message explaining the revocation
+  String? get message;
+  @override
+
+  /// Timestamp when the revocation occurred
+  DateTime? get timestamp;
+  @override
+  @JsonKey(ignore: true)
+  _$$ApiKeyRevocationEventImplCopyWith<_$ApiKeyRevocationEventImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/core/models/api_key_revocation_event.g.dart
+++ b/lib/core/models/api_key_revocation_event.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'api_key_revocation_event.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ApiKeyRevocationEventImpl _$$ApiKeyRevocationEventImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ApiKeyRevocationEventImpl(
+      reason: json['reason'] as String,
+      message: json['message'] as String?,
+      timestamp: json['timestamp'] == null
+          ? null
+          : DateTime.parse(json['timestamp'] as String),
+    );
+
+Map<String, dynamic> _$$ApiKeyRevocationEventImplToJson(
+    _$ApiKeyRevocationEventImpl instance) {
+  final val = <String, dynamic>{
+    'reason': instance.reason,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('message', instance.message);
+  writeNotNull('timestamp', instance.timestamp?.toIso8601String());
+  return val;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -216,10 +216,12 @@ class _FDKAppState extends ConsumerState<FDKApp> {
         ref.read(initializationNotifierProvider.notifier).initialize();
       } else if (!isAuthenticated && wasAuthenticated) {
         LoggerService.info(
-          'User signed out, resetting initialization state',
+          'User signed out, navigating to auth screen',
           tag: 'Init',
         );
         ref.read(initializationNotifierProvider.notifier).reset();
+        // Navigate to auth screen so user can sign back in
+        AppRouter.router.go('/auth');
       }
     });
 


### PR DESCRIPTION
## Summary

- **Alert Navigation**: Clicking health notices now navigates to the associated device or room
- **Large Font Overflow Fix**: Global 1.3x text scale limit + badge sizing fixes to prevent RenderFlex overflow
- **Theme Toggle Removal**: Removed non-functional theme picker, app stays dark mode only
- **API Key Revocation Handling**: When server revokes API key (e.g., new key generated), app detects it and signs out automatically

## API Key Revocation Details

### Client-Side (FDK)
- Added `ApiKeyRevocationEvent` model for server revocation messages
- Detect revocation via WebSocket (handles ActionCable message wrapping)
- Fallback detection via reconnect failure tracking (3+ failures triggers sign out)
- Triggers `signOut()` on revocation (same behavior as clicking sign out button)
- Navigates to auth screen after sign out for re-authentication

### Server-Side (RXG - separate repo)
- Added `ApiKeyRevocationNotifier` service to broadcast revocation via ActionCable
- Hooks into `ApiKey` model lifecycle (`after_destroy`, `after_commit` on create)
- Added `RxgChannel.force_disconnect` for admin-initiated revocation

## Test Plan

- [x] Verify clicking health notice navigates to device/room
- [x] Verify large font sizes don't cause overflow errors
- [x] Verify API key revocation triggers sign out and redirects to auth screen
- [x] Verify normal sign out still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)