### PR TITLE
Add sign-out reason dialog when API key is revoked

### DIFF
--- a/lib/features/auth/presentation/providers/auth_notifier.dart
+++ b/lib/features/auth/presentation/providers/auth_notifier.dart
@@ -27,6 +27,7 @@ import 'package:rgnets_fdk/features/notifications/presentation/providers/device_
     as device_notifications;
 import 'package:rgnets_fdk/features/notifications/presentation/providers/notifications_domain_provider.dart'
     as notifications_domain;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'auth_notifier.g.dart';
@@ -399,6 +400,9 @@ class Auth extends _$Auth {
     }
 
     _logger.i('AUTH_NOTIFIER: Triggering sign out due to reconnect failures');
+    // Set the reason so the UI can show a message to the user
+    ref.read(signOutReasonProvider.notifier).state =
+        'Unable to reconnect to server. Your session may have expired.';
     unawaited(signOut());
   }
 
@@ -415,6 +419,9 @@ class Auth extends _$Auth {
     }
 
     _logger.i('AUTH_NOTIFIER: Triggering sign out due to API key revocation');
+    // Set the reason so the UI can show a message to the user
+    ref.read(signOutReasonProvider.notifier).state = event.message ??
+        'Your session has been invalidated. Please sign in again.';
     unawaited(signOut());
   }
 
@@ -636,6 +643,12 @@ AuthStatus? authStatus(AuthStatusRef ref) {
   final authAsync = ref.watch(authProvider);
   return authAsync.valueOrNull;
 }
+
+/// Provider that holds the reason for the last sign-out.
+/// Used to show a message to the user when they're redirected to the auth screen
+/// due to API key revocation or connection failures.
+/// The message is cleared after being read.
+final signOutReasonProvider = StateProvider<String?>((ref) => null);
 
 /// Listener provider that handles cleanup when auth state changes to unauthenticated.
 /// This is separated from Auth.signOut() to avoid CircularDependencyError when

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -220,6 +220,48 @@ class _FDKAppState extends ConsumerState<FDKApp> {
           tag: 'Init',
         );
         ref.read(initializationNotifierProvider.notifier).reset();
+
+        // Check if there's a sign-out reason to display
+        final signOutReason = ref.read(signOutReasonProvider);
+        if (signOutReason != null) {
+          // Clear the reason so it doesn't show again
+          ref.read(signOutReasonProvider.notifier).state = null;
+
+          // Show dialog explaining why the user was signed out
+          final navigatorContext =
+              AppRouter.router.routerDelegate.navigatorKey.currentContext;
+          if (navigatorContext != null) {
+            LoggerService.info(
+              'Showing sign-out reason dialog',
+              tag: 'Auth',
+            );
+            showDialog<void>(
+              context: navigatorContext,
+              barrierDismissible: false,
+              builder: (context) => AlertDialog(
+                title: const Row(
+                  children: [
+                    Icon(Icons.info_outline, color: Colors.orange),
+                    SizedBox(width: 12),
+                    Expanded(child: Text('Session Ended')),
+                  ],
+                ),
+                content: Text(signOutReason),
+                actions: [
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      AppRouter.router.go('/auth');
+                    },
+                    child: const Text('Sign In'),
+                  ),
+                ],
+              ),
+            );
+            return; // Don't navigate yet - dialog will handle it
+          }
+        }
+
         // Navigate to auth screen so user can sign back in
         AppRouter.router.go('/auth');
       }


### PR DESCRIPTION
## Summary
- Adds a dialog that explains to the user why they were signed out when their API key is revoked
- When server revokes an API key (e.g., by generating a new one), the app now shows an informative dialog before redirecting to auth screen
- Improves user experience by providing context instead of silently signing out

## Changes
- Added `signOutReasonProvider` to store the sign-out reason
- Modified `_handleApiKeyRevocation` and `_handlePotentialAuthFailure` to set the reason
- Added AlertDialog in main.dart that displays when there's a sign-out reason

## Test plan
- [ ] Generate a new API key on the server while the app is connected
- [ ] Verify the app shows a dialog explaining the session ended
- [ ] Click "Sign In" button and verify navigation to auth screen
- [ ] Sign back in and verify normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)