### PR TITLE
Add offline indicator banner

### DIFF
--- a/lib/core/providers/connectivity_provider.dart
+++ b/lib/core/providers/connectivity_provider.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:rgnets_fdk/core/providers/websocket_providers.dart';
+import 'package:rgnets_fdk/core/services/websocket_service.dart';
+
+part 'connectivity_provider.g.dart';
+
+/// Represents the app's overall connection status.
+enum AppConnectionStatus {
+  online,
+  offline,
+  connecting,
+  reconnecting,
+}
+
+/// Provider that combines WebSocket connection state with device connectivity
+/// to determine the overall app connection status.
+@riverpod
+Stream<AppConnectionStatus> appConnectionStatus(AppConnectionStatusRef ref) {
+  final controller = StreamController<AppConnectionStatus>();
+  final connectivity = Connectivity();
+
+  // Listen to WebSocket state changes
+  final wsSubscription = ref.listen(webSocketConnectionStateProvider, (previous, next) async {
+    final wsState = next.valueOrNull;
+    if (wsState == null) return;
+
+    // Check device connectivity
+    final connectivityResult = await connectivity.checkConnectivity();
+    final hasInternet = !connectivityResult.contains(ConnectivityResult.none);
+
+    if (!hasInternet) {
+      controller.add(AppConnectionStatus.offline);
+    } else {
+      controller.add(switch (wsState) {
+        SocketConnectionState.connected => AppConnectionStatus.online,
+        SocketConnectionState.disconnected => AppConnectionStatus.offline,
+        SocketConnectionState.connecting => AppConnectionStatus.connecting,
+        SocketConnectionState.reconnecting => AppConnectionStatus.reconnecting,
+      });
+    }
+  }, fireImmediately: true);
+
+  // Listen to device connectivity changes
+  final connectivitySubscription = connectivity.onConnectivityChanged.listen((result) async {
+    final hasInternet = !result.contains(ConnectivityResult.none);
+    final wsState = ref.read(webSocketConnectionStateProvider).valueOrNull;
+
+    if (!hasInternet) {
+      controller.add(AppConnectionStatus.offline);
+    } else if (wsState != null) {
+      controller.add(switch (wsState) {
+        SocketConnectionState.connected => AppConnectionStatus.online,
+        SocketConnectionState.disconnected => AppConnectionStatus.offline,
+        SocketConnectionState.connecting => AppConnectionStatus.connecting,
+        SocketConnectionState.reconnecting => AppConnectionStatus.reconnecting,
+      });
+    }
+  });
+
+  ref.onDispose(() {
+    wsSubscription.close();
+    connectivitySubscription.cancel();
+    controller.close();
+  });
+
+  return controller.stream;
+}

--- a/lib/core/providers/connectivity_provider.g.dart
+++ b/lib/core/providers/connectivity_provider.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'connectivity_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$appConnectionStatusHash() =>
+    r'5ce12ee7f55cba3eb26f84d491f9f9c3cfe5ef4d';
+
+/// Provider that combines WebSocket connection state with device connectivity
+/// to determine the overall app connection status.
+///
+/// Copied from [appConnectionStatus].
+@ProviderFor(appConnectionStatus)
+final appConnectionStatusProvider =
+    AutoDisposeStreamProvider<AppConnectionStatus>.internal(
+  appConnectionStatus,
+  name: r'appConnectionStatusProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appConnectionStatusHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef AppConnectionStatusRef
+    = AutoDisposeStreamProviderRef<AppConnectionStatus>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/core/widgets/main_scaffold.dart
+++ b/lib/core/widgets/main_scaffold.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:rgnets_fdk/core/providers/app_bar_provider.dart';
 import 'package:rgnets_fdk/core/services/logger_service.dart';
 import 'package:rgnets_fdk/core/widgets/fdk_app_bar.dart';
+import 'package:rgnets_fdk/core/widgets/offline_banner.dart';
 import 'package:rgnets_fdk/features/initialization/initialization.dart';
 import 'package:rgnets_fdk/features/issues/presentation/providers/health_notices_provider.dart';
 
@@ -76,7 +77,12 @@ class _MainScaffoldState extends ConsumerState<MainScaffold> with TickerProvider
       children: [
         Scaffold(
           appBar: const FDKAppBar(),
-          body: widget.child,
+          body: Column(
+            children: [
+              Expanded(child: widget.child),
+              const OfflineBanner(),
+            ],
+          ),
           bottomNavigationBar: DecoratedBox(
         decoration: BoxDecoration(
           boxShadow: [

--- a/lib/core/widgets/offline_banner.dart
+++ b/lib/core/widgets/offline_banner.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rgnets_fdk/core/providers/connectivity_provider.dart';
+import 'package:rgnets_fdk/core/theme/app_colors.dart';
+
+/// A banner widget that displays the app's connection status.
+/// Shows at the bottom of the screen when offline, connecting, or reconnecting.
+/// Hides automatically when online.
+class OfflineBanner extends ConsumerWidget {
+  const OfflineBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connectionStatus = ref.watch(appConnectionStatusProvider);
+
+    return connectionStatus.when(
+      data: (status) => _buildBanner(status),
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => _buildBanner(AppConnectionStatus.offline),
+    );
+  }
+
+  Widget _buildBanner(AppConnectionStatus status) {
+    if (status == AppConnectionStatus.online) {
+      return const SizedBox.shrink();
+    }
+
+    final (color, icon, message) = switch (status) {
+      AppConnectionStatus.offline => (
+        AppColors.error,
+        Icons.cloud_off,
+        'No connection',
+      ),
+      AppConnectionStatus.connecting => (
+        AppColors.warning,
+        Icons.cloud_sync,
+        'Connecting...',
+      ),
+      AppConnectionStatus.reconnecting => (
+        AppColors.warning,
+        Icons.cloud_sync,
+        'Reconnecting...',
+      ),
+      AppConnectionStatus.online => (
+        AppColors.success,
+        Icons.cloud_done,
+        'Connected',
+      ),
+    };
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      color: color,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, color: Colors.white, size: 18),
+          const SizedBox(width: 8),
+          Text(
+            message,
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a persistent offline indicator banner visible on all main screens
- Shows connection status when offline, connecting, or reconnecting
- Banner automatically hides when online

## Changes
- Created `AppConnectionStatus` enum and `appConnectionStatusProvider` combining WebSocket state with device connectivity
- Created `OfflineBanner` widget that displays status with appropriate colors/icons
- Integrated banner into `MainScaffold` above bottom navigation

## Visual Design
| State | Color | Icon | Message |
|-------|-------|------|---------|
| Offline | Red | cloud_off | "No connection" |
| Connecting | Yellow | cloud_sync | "Connecting..." |
| Reconnecting | Yellow | cloud_sync | "Reconnecting..." |
| Online | (hidden) | - | - |

## Test plan
- [x] Turn on airplane mode - banner shows "No connection"
- [x] Turn off airplane mode - banner shows "Connecting..." then hides
- [x] Disconnect WebSocket server - banner shows reconnection status
- [x] Verify banner visible on all main screens (Home, Scanner, Devices, etc.)
- [x] Verify banner doesn't interfere with bottom navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)