### PR TITLE
Add skeleton loading for list screens

### DIFF
--- a/lib/core/widgets/skeleton/device_card_skeleton.dart
+++ b/lib/core/widgets/skeleton/device_card_skeleton.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:rgnets_fdk/core/widgets/skeleton/skeleton_base.dart';
+
+/// Skeleton placeholder matching DeviceCard layout
+class DeviceCardSkeleton extends StatelessWidget {
+  const DeviceCardSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SkeletonShimmer(
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              // Device icon placeholder
+              const SkeletonCircle(size: 48),
+              const SizedBox(width: 16),
+              // Text content
+              const Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SkeletonBox(width: 120, height: 16), // Device name
+                    SizedBox(height: 8),
+                    SkeletonBox(width: 180, height: 12), // MAC address
+                    SizedBox(height: 4),
+                    SkeletonBox(width: 80, height: 12), // Status
+                  ],
+                ),
+              ),
+              // Status indicator
+              const SkeletonCircle(size: 12),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// List of device card skeletons
+class DeviceListSkeleton extends StatelessWidget {
+  const DeviceListSkeleton({super.key, this.itemCount = 6});
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: itemCount,
+      itemBuilder: (context, index) => const Padding(
+        padding: EdgeInsets.only(bottom: 12),
+        child: DeviceCardSkeleton(),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/skeleton/device_detail_skeleton.dart
+++ b/lib/core/widgets/skeleton/device_detail_skeleton.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:rgnets_fdk/core/widgets/skeleton/skeleton_base.dart';
+
+/// Skeleton placeholder for device detail screen
+class DeviceDetailSkeleton extends StatelessWidget {
+  const DeviceDetailSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SkeletonShimmer(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header with image
+            const _DeviceHeaderSkeleton(),
+            const SizedBox(height: 24),
+            // Info section
+            const _SectionSkeleton(titleWidth: 100, rows: 4),
+            const SizedBox(height: 24),
+            // Status section
+            const _SectionSkeleton(titleWidth: 80, rows: 3),
+            const SizedBox(height: 24),
+            // Actions
+            const _ActionButtonsSkeleton(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DeviceHeaderSkeleton extends StatelessWidget {
+  const _DeviceHeaderSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          // Image placeholder
+          Container(
+            height: 200,
+            width: double.infinity,
+            color: Colors.grey[700],
+          ),
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SkeletonBox(width: 180, height: 24),
+                SizedBox(height: 8),
+                SkeletonBox(width: 140, height: 14),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionSkeleton extends StatelessWidget {
+  const _SectionSkeleton({required this.titleWidth, required this.rows});
+  final double titleWidth;
+  final int rows;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SkeletonBox(width: titleWidth, height: 18),
+            const SizedBox(height: 16),
+            ...List.generate(
+              rows,
+              (index) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    SkeletonBox(width: 80 + (index * 10), height: 14),
+                    const SkeletonBox(width: 100, height: 14),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionButtonsSkeleton extends StatelessWidget {
+  const _ActionButtonsSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Row(
+      children: [
+        Expanded(child: SkeletonBox(height: 48, borderRadius: 8)),
+        SizedBox(width: 12),
+        Expanded(child: SkeletonBox(height: 48, borderRadius: 8)),
+      ],
+    );
+  }
+}

--- a/lib/core/widgets/skeleton/room_card_skeleton.dart
+++ b/lib/core/widgets/skeleton/room_card_skeleton.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:rgnets_fdk/core/widgets/skeleton/skeleton_base.dart';
+
+/// Skeleton placeholder matching RoomCard layout
+class RoomCardSkeleton extends StatelessWidget {
+  const RoomCardSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SkeletonShimmer(
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const SkeletonCircle(size: 40), // Room icon
+                  const SizedBox(width: 12),
+                  const Expanded(
+                    child: SkeletonBox(width: 100, height: 18), // Room name
+                  ),
+                  const SkeletonBox(
+                    width: 60,
+                    height: 24,
+                    borderRadius: 12,
+                  ), // Badge
+                ],
+              ),
+              const SizedBox(height: 12),
+              const SkeletonBox(height: 12), // Device count
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// List of room card skeletons
+class RoomListSkeleton extends StatelessWidget {
+  const RoomListSkeleton({super.key, this.itemCount = 8});
+  final int itemCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: itemCount,
+      itemBuilder: (context, index) => const Padding(
+        padding: EdgeInsets.only(bottom: 12),
+        child: RoomCardSkeleton(),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/skeleton/skeleton.dart
+++ b/lib/core/widgets/skeleton/skeleton.dart
@@ -1,0 +1,4 @@
+export 'skeleton_base.dart';
+export 'device_card_skeleton.dart';
+export 'room_card_skeleton.dart';
+export 'device_detail_skeleton.dart';

--- a/lib/core/widgets/skeleton/skeleton_base.dart
+++ b/lib/core/widgets/skeleton/skeleton_base.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// Base shimmer wrapper for skeleton loading effects
+class SkeletonShimmer extends StatelessWidget {
+  const SkeletonShimmer({required this.child, super.key});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // Use theme-aware colors for shimmer effect
+    final baseColor = theme.brightness == Brightness.dark
+        ? Colors.grey[800]!
+        : Colors.grey[300]!;
+    final highlightColor = theme.brightness == Brightness.dark
+        ? Colors.grey[600]!
+        : Colors.grey[100]!;
+
+    return Shimmer.fromColors(
+      baseColor: baseColor,
+      highlightColor: highlightColor,
+      child: child,
+    );
+  }
+}
+
+/// Skeleton box placeholder
+class SkeletonBox extends StatelessWidget {
+  const SkeletonBox({
+    super.key,
+    this.width,
+    this.height = 16,
+    this.borderRadius = 4,
+  });
+  final double? width;
+  final double height;
+  final double borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: Colors.grey[700],
+        borderRadius: BorderRadius.circular(borderRadius),
+      ),
+    );
+  }
+}
+
+/// Skeleton circle placeholder (for avatars, icons)
+class SkeletonCircle extends StatelessWidget {
+  const SkeletonCircle({super.key, this.size = 40});
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: Colors.grey[700],
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/widgets.dart
+++ b/lib/core/widgets/widgets.dart
@@ -10,3 +10,4 @@ export 'loading_indicator.dart';
 export 'main_scaffold.dart';
 export 'search_bar_widget.dart';
 export 'section_card.dart';
+export 'skeleton/skeleton.dart';

--- a/lib/features/devices/presentation/screens/device_detail_screen.dart
+++ b/lib/features/devices/presentation/screens/device_detail_screen.dart
@@ -64,7 +64,7 @@ class _DeviceDetailScreenState extends ConsumerState<DeviceDetailScreen>
       loading: () {
         // AppBar removed from loading state
         return const Scaffold(
-          body: Center(child: LoadingIndicator()),
+          body: DeviceDetailSkeleton(),
         );
       },
       error: (error, stack) {

--- a/lib/features/devices/presentation/screens/devices_screen.dart
+++ b/lib/features/devices/presentation/screens/devices_screen.dart
@@ -754,7 +754,7 @@ class _DevicesScreenState extends ConsumerState<DevicesScreen> {
           final mockDataState = ref.watch(mockDataStateProvider);
 
           return devicesAsync.when(
-            loading: () => const Center(child: LoadingIndicator()),
+            loading: () => const DeviceListSkeleton(),
             error: (error, stack) => Center(
               child: EmptyState(
                 icon: Icons.error_outline,

--- a/lib/features/rooms/presentation/screens/rooms_screen.dart
+++ b/lib/features/rooms/presentation/screens/rooms_screen.dart
@@ -61,7 +61,7 @@ class _RoomsScreenState extends ConsumerState<RoomsScreen> {
           final filteredRooms = ref.watch(filteredRoomViewModelsProvider(currentFilter));
           
           return roomsAsync.when(
-            loading: () => const Center(child: LoadingIndicator()),
+            loading: () => const RoomListSkeleton(),
             error: (error, stack) => Center(
               child: EmptyState(
                 icon: Icons.error_outline,


### PR DESCRIPTION
## Summary
- Adds shimmer-based skeleton loading placeholders for better UX during initial data load
- Replaces spinner-only loading with content-shaped skeletons that match screen layouts
- Makes perceived loading time feel faster by showing structure immediately

## Changes

### New Files
| File | Description |
|------|-------------|
| `skeleton_base.dart` | Base primitives: SkeletonShimmer (theme-aware), SkeletonBox, SkeletonCircle |
| `device_card_skeleton.dart` | DeviceCardSkeleton, DeviceListSkeleton |
| `room_card_skeleton.dart` | RoomCardSkeleton, RoomListSkeleton |
| `device_detail_skeleton.dart` | DeviceDetailSkeleton with header, sections, actions |
| `skeleton.dart` | Barrel export |

### Modified Files
| File | Change |
|------|--------|
| `devices_screen.dart` | Use DeviceListSkeleton in loading state |
| `rooms_screen.dart` | Use RoomListSkeleton in loading state |
| `device_detail_screen.dart` | Use DeviceDetailSkeleton in loading state |
| `widgets.dart` | Export skeleton module |

## Design Decisions
- **Theme-aware shimmer**: Colors adapt to light/dark mode
- **Home screen unchanged**: Uses progressive loading (each widget loads independently) which is preferable to monolithic skeleton
- **Shimmer package**: Already installed (^3.0.0), now utilized

## Test plan
- [x] Open Devices screen - skeleton appears briefly during initial load
- [x] Open Rooms screen - skeleton appears briefly during initial load
- [x] Open Device Detail - skeleton appears briefly during initial load
- [x] Verify shimmer animation runs smoothly
- [x] Verify skeleton hides and content appears without jarring layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)