### PR TITLE
Address all 18 findings from code review council audit

### DIFF
--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -34,8 +34,10 @@ class AppConfig {
   }
 
   /// Get the API base URL
+  @Deprecated('FDK uses WebSocket-only communication. '
+      'Use EnvironmentConfig.webSocketUrl instead.')
   static String get apiBaseUrl {
-    // This is deprecated - use EnvironmentConfig.apiBaseUrl instead
+    // ignore: deprecated_member_use_from_same_package
     return EnvironmentConfig.apiBaseUrl;
   }
 

--- a/lib/core/services/websocket_channel_factory_web.dart
+++ b/lib/core/services/websocket_channel_factory_web.dart
@@ -1,8 +1,22 @@
+import 'package:rgnets_fdk/core/services/logger_service.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+/// Creates a WebSocket channel for the web platform.
+///
+/// Note: Browser WebSocket APIs do not support custom headers.
+/// The [headers] parameter (including Authorization) is ignored on web.
+/// Authentication must rely on query parameters (e.g., api_key) instead.
 WebSocketChannel createWebSocketChannel(
   Uri uri, {
   Map<String, dynamic>? headers,
 }) {
+  if (headers != null && headers.isNotEmpty) {
+    LoggerService.warning(
+      'WebSocket headers are not supported on web platform. '
+      'Authorization header will not be sent. '
+      'Ensure api_key query parameter is included for authentication.',
+      tag: 'WebSocketChannelFactory',
+    );
+  }
   return WebSocketChannel.connect(uri);
 }

--- a/lib/features/auth/data/services/action_cable_auth_service.dart
+++ b/lib/features/auth/data/services/action_cable_auth_service.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:logger/logger.dart';
+import 'package:rgnets_fdk/core/config/environment.dart';
+import 'package:rgnets_fdk/core/services/websocket_service.dart';
+
+/// Result of an ActionCable authentication handshake.
+class ActionCableAuthResult {
+  const ActionCableAuthResult.success()
+      : success = true,
+        message = '';
+  const ActionCableAuthResult.failure(this.message) : success = false;
+
+  final bool success;
+  final String message;
+}
+
+/// Handles the ActionCable WebSocket handshake protocol.
+///
+/// This service is responsible for:
+/// - Building the ActionCable URI with authentication query parameters
+/// - Connecting to the WebSocket server
+/// - Subscribing to the RxgChannel
+/// - Waiting for subscription confirmation or rejection
+///
+/// It does NOT manage authentication state (credentials, sessions, etc.).
+/// That responsibility remains with the AuthNotifier.
+class ActionCableAuthService {
+  ActionCableAuthService({
+    required WebSocketService webSocketService,
+    required Logger logger,
+  })  : _service = webSocketService,
+        _logger = logger;
+
+  final WebSocketService _service;
+  final Logger _logger;
+
+  /// Performs the ActionCable handshake: connect, subscribe, await confirmation.
+  ///
+  /// Returns [ActionCableAuthResult.success] if the subscription is confirmed,
+  /// or [ActionCableAuthResult.failure] with a reason string otherwise.
+  Future<ActionCableAuthResult> performHandshake({
+    required String fqdn,
+    required String token,
+    required Uri baseUri,
+    Duration connectionTimeout = const Duration(seconds: 10),
+    Duration subscriptionTimeout = const Duration(seconds: 15),
+  }) async {
+    final uri = buildActionCableUri(
+      baseUri: baseUri,
+      fqdn: fqdn,
+      token: token,
+    );
+    final headers = buildAuthHeaders(token);
+
+    if (_service.isConnected) {
+      await _service.disconnect(code: 4000, reason: 'Re-authenticating');
+    }
+
+    final identifier = jsonEncode(const {'channel': 'RxgChannel'});
+    final subscriptionPayload = <String, dynamic>{
+      'command': 'subscribe',
+      'identifier': identifier,
+    };
+
+    final completer = Completer<ActionCableAuthResult>();
+
+    final subscription = _service.messages.listen((message) {
+      _logger.d(
+        'ActionCableAuth: message received: '
+        'type=${message.type}, payload=${message.payload}',
+      );
+      if (message.type == 'confirm_subscription' &&
+          _identifierMatches(message, identifier)) {
+        _logger.i('ActionCableAuth: Subscription confirmed');
+        if (!completer.isCompleted) {
+          completer.complete(const ActionCableAuthResult.success());
+        }
+      } else if (message.type == 'reject_subscription' &&
+          _identifierMatches(message, identifier)) {
+        _logger.e('ActionCableAuth: Subscription REJECTED by server');
+        if (!completer.isCompleted) {
+          completer.complete(
+            const ActionCableAuthResult.failure(
+              'Subscription rejected by server',
+            ),
+          );
+        }
+      } else if (message.type == 'disconnect') {
+        final reason = message.payload['reason'] as String? ??
+            message.payload['message'] as String?;
+        _logger.e('ActionCableAuth: Server sent disconnect: $reason');
+        if (!completer.isCompleted) {
+          completer.complete(
+            ActionCableAuthResult.failure(
+              reason ?? 'Connection closed by server',
+            ),
+          );
+        }
+      }
+    });
+
+    final stateSubscription = _service.connectionState.listen((connState) {
+      _logger.d('ActionCableAuth: connection state changed: $connState');
+      if (connState == SocketConnectionState.disconnected &&
+          !completer.isCompleted) {
+        _logger.e(
+          'ActionCableAuth: Connection closed before subscription confirmed',
+        );
+        completer.complete(
+          const ActionCableAuthResult.failure(
+            'Connection closed before subscription confirmed',
+          ),
+        );
+      }
+    });
+
+    _logger
+      ..i('ActionCableAuth: Initiating WebSocket handshake')
+      ..d('ActionCableAuth: WebSocket URI: $uri')
+      ..d('ActionCableAuth: Subscription identifier: $identifier');
+
+    try {
+      _logger.d('ActionCableAuth: Calling service.connect()...');
+      await _service
+          .connect(WebSocketConnectionParams(uri: uri, headers: headers))
+          .timeout(
+        connectionTimeout,
+        onTimeout: () {
+          _logger.e(
+            'ActionCableAuth: Connection TIMED OUT '
+            'after ${connectionTimeout.inSeconds} seconds',
+          );
+          throw TimeoutException('Connection to server timed out');
+        },
+      );
+
+      _logger.d('ActionCableAuth: Connected, sending subscription...');
+      _service.send(subscriptionPayload);
+      _logger.d(
+        'ActionCableAuth: Subscription sent, '
+        'waiting for confirmation (${subscriptionTimeout.inSeconds}s timeout)...',
+      );
+
+      final result = await completer.future.timeout(
+        subscriptionTimeout,
+        onTimeout: () {
+          _logger.e(
+            'ActionCableAuth: Handshake TIMED OUT '
+            'after ${subscriptionTimeout.inSeconds} seconds',
+          );
+          return const ActionCableAuthResult.failure(
+            'WebSocket handshake timed out',
+          );
+        },
+      );
+
+      return result;
+    } finally {
+      await subscription.cancel();
+      await stateSubscription.cancel();
+    }
+  }
+
+  /// Builds the ActionCable WebSocket URI with authentication query parameters.
+  static Uri buildActionCableUri({
+    required Uri baseUri,
+    required String fqdn,
+    required String token,
+  }) {
+    final useBaseUri = EnvironmentConfig.isDevelopment;
+    final uri = useBaseUri
+        ? baseUri
+        : Uri(
+            scheme: 'wss',
+            host: fqdn,
+            path: '/cable',
+          );
+
+    final queryParameters = Map<String, String>.from(uri.queryParameters);
+    if (token.isNotEmpty) {
+      queryParameters['api_key'] = token;
+    }
+
+    return uri.replace(
+      queryParameters: queryParameters.isEmpty ? null : queryParameters,
+    );
+  }
+
+  /// Builds authorization headers for the WebSocket connection.
+  static Map<String, dynamic> buildAuthHeaders(String token) {
+    if (token.isEmpty) {
+      return const {};
+    }
+    return {'Authorization': 'Bearer $token'};
+  }
+
+  static bool _identifierMatches(SocketMessage message, String identifier) {
+    final headerIdentifier = message.headers?['identifier'];
+    if (headerIdentifier is String && headerIdentifier.isNotEmpty) {
+      return headerIdentifier == identifier;
+    }
+    return false;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -859,10 +859,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1456,10 +1456,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:

--- a/test/core/services/websocket_data_sync_service_test.dart
+++ b/test/core/services/websocket_data_sync_service_test.dart
@@ -1,0 +1,487 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:rgnets_fdk/core/services/cache_manager.dart';
+import 'package:rgnets_fdk/core/services/storage_service.dart';
+import 'package:rgnets_fdk/core/services/websocket_data_sync_service.dart';
+import 'package:rgnets_fdk/core/services/websocket_service.dart';
+import 'package:rgnets_fdk/features/devices/data/datasources/typed_device_local_data_source.dart';
+import 'package:rgnets_fdk/features/devices/data/models/device_model_sealed.dart';
+import 'package:rgnets_fdk/features/devices/data/models/room_model.dart';
+import 'package:rgnets_fdk/features/rooms/data/datasources/room_local_data_source.dart';
+
+class MockWebSocketService extends Mock implements WebSocketService {}
+
+class MockAPLocalDataSource extends Mock implements APLocalDataSource {}
+
+class MockONTLocalDataSource extends Mock implements ONTLocalDataSource {}
+
+class MockSwitchLocalDataSource extends Mock implements SwitchLocalDataSource {}
+
+class MockWLANLocalDataSource extends Mock implements WLANLocalDataSource {}
+
+class MockRoomLocalDataSource extends Mock implements RoomLocalDataSource {}
+
+class MockCacheManager extends Mock implements CacheManager {}
+
+class MockStorageService extends Mock implements StorageService {}
+
+
+void main() {
+  late MockWebSocketService mockWebSocketService;
+  late MockAPLocalDataSource mockAPDataSource;
+  late MockONTLocalDataSource mockONTDataSource;
+  late MockSwitchLocalDataSource mockSwitchDataSource;
+  late MockWLANLocalDataSource mockWLANDataSource;
+  late MockRoomLocalDataSource mockRoomDataSource;
+  late MockCacheManager mockCacheManager;
+  late MockStorageService mockStorageService;
+  late StreamController<SocketMessage> messageController;
+  late StreamController<SocketConnectionState> stateController;
+  late WebSocketDataSyncService service;
+
+  setUpAll(() {
+    // Register fallback values BEFORE any setUp that uses any()
+    registerFallbackValue(<DeviceModelSealed>[]);
+    registerFallbackValue(<RoomModel>[]);
+    registerFallbackValue(Duration.zero);
+    registerFallbackValue(const SocketMessage(type: '', payload: {}));
+  });
+
+  setUp(() {
+    mockWebSocketService = MockWebSocketService();
+    mockAPDataSource = MockAPLocalDataSource();
+    mockONTDataSource = MockONTLocalDataSource();
+    mockSwitchDataSource = MockSwitchLocalDataSource();
+    mockWLANDataSource = MockWLANLocalDataSource();
+    mockRoomDataSource = MockRoomLocalDataSource();
+    mockCacheManager = MockCacheManager();
+    mockStorageService = MockStorageService();
+    messageController = StreamController<SocketMessage>.broadcast();
+    stateController = StreamController<SocketConnectionState>.broadcast();
+
+    when(() => mockWebSocketService.messages)
+        .thenAnswer((_) => messageController.stream);
+    when(() => mockWebSocketService.connectionState)
+        .thenAnswer((_) => stateController.stream);
+    when(() => mockWebSocketService.isConnected).thenReturn(true);
+    when(() => mockWebSocketService.send(any())).thenReturn(null);
+    when(() => mockWebSocketService.requestActionCable(
+          action: any(named: 'action'),
+          resourceType: any(named: 'resourceType'),
+          timeout: any(named: 'timeout'),
+        )).thenAnswer((_) async => const SocketMessage(
+          type: 'response',
+          payload: {'data': []},
+        ));
+
+    // Storage mock defaults
+    when(() => mockStorageService.token).thenReturn('test-token');
+
+    service = WebSocketDataSyncService(
+      socketService: mockWebSocketService,
+      apLocalDataSource: mockAPDataSource,
+      ontLocalDataSource: mockONTDataSource,
+      switchLocalDataSource: mockSwitchDataSource,
+      wlanLocalDataSource: mockWLANDataSource,
+      roomLocalDataSource: mockRoomDataSource,
+      cacheManager: mockCacheManager,
+      storageService: mockStorageService,
+      logger: Logger(level: Level.off),
+    );
+  });
+
+  tearDown(() async {
+    service.stop();
+    await messageController.close();
+    await stateController.close();
+  });
+
+  group('WebSocketDataSyncService', () {
+    group('events stream', () {
+      test('emits events when created', () {
+        expect(service.events, isNotNull);
+      });
+    });
+
+    group('start and stop', () {
+      test('start subscribes to websocket messages', () {
+        service.start();
+
+        verify(() => mockWebSocketService.messages).called(greaterThan(0));
+      });
+
+      test('stop cancels subscriptions', () {
+        service.start();
+        service.stop();
+
+        // Should not throw when stop is called again
+        service.stop();
+      });
+    });
+
+    group('message handling with data key', () {
+      test('processes device snapshot from data key', () async {
+        // Stub cache methods
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        // Simulate a snapshot message with 'data' key (backend format)
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {
+                'id': 1,
+                'name': 'AP-100',
+                'type': 'AccessPoint',
+                'online': true,
+                'mac_address': 'AA:BB:CC:DD:EE:FF',
+              },
+              {
+                'id': 2,
+                'name': 'AP-200',
+                'type': 'AccessPoint',
+                'online': false,
+                'mac_address': '11:22:33:44:55:66',
+              },
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        // Wait for async processing
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verify(() => mockAPDataSource.cacheDevices(any())).called(1);
+      });
+
+      test('processes device snapshot from results key (fallback)', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'results': [
+              {
+                'id': 1,
+                'name': 'AP-100',
+                'type': 'AccessPoint',
+                'online': true,
+              },
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verify(() => mockAPDataSource.cacheDevices(any())).called(1);
+      });
+    });
+
+    group('device status determination', () {
+      test('online boolean true maps to online status', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {'id': 1, 'name': 'AP-1', 'type': 'AccessPoint', 'online': true},
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockAPDataSource.cacheDevices(captureAny()),
+        ).captured.first as List<DeviceModelSealed>;
+
+        expect(captured.first.status, 'online');
+      });
+
+      test('online boolean false maps to offline status', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {'id': 1, 'name': 'AP-1', 'type': 'AccessPoint', 'online': false},
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockAPDataSource.cacheDevices(captureAny()),
+        ).captured.first as List<DeviceModelSealed>;
+
+        expect(captured.first.status, 'offline');
+      });
+
+      test('string status online is preserved', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {'id': 1, 'name': 'AP-1', 'type': 'AccessPoint', 'status': 'online'},
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockAPDataSource.cacheDevices(captureAny()),
+        ).captured.first as List<DeviceModelSealed>;
+
+        expect(captured.first.status, 'online');
+      });
+
+      test('no status info defaults to unknown', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {'id': 1, 'name': 'AP-1', 'type': 'AccessPoint'},
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockAPDataSource.cacheDevices(captureAny()),
+        ).captured.first as List<DeviceModelSealed>;
+
+        expect(captured.first.status, 'unknown');
+      });
+    });
+
+    group('image extraction', () {
+      test('extracts images from images list', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {
+                'id': 1,
+                'name': 'AP-1',
+                'type': 'AccessPoint',
+                'online': true,
+                'images': ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+              },
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockAPDataSource.cacheDevices(captureAny()),
+        ).captured.first as List<DeviceModelSealed>;
+
+        expect(captured.first.images, hasLength(2));
+        expect(captured.first.images?.first, 'https://example.com/img1.jpg');
+      });
+
+      test('extracts images from image objects with url key', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {
+                'id': 1,
+                'name': 'AP-1',
+                'type': 'AccessPoint',
+                'online': true,
+                'images': [
+                  {'url': 'https://example.com/img1.jpg'},
+                  {'url': 'https://example.com/img2.jpg'},
+                ],
+              },
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockAPDataSource.cacheDevices(captureAny()),
+        ).captured.first as List<DeviceModelSealed>;
+
+        expect(captured.first.images, hasLength(2));
+      });
+
+      test('returns null when no images present', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'access_points',
+            'data': [
+              {'id': 1, 'name': 'AP-1', 'type': 'AccessPoint', 'online': true},
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final captured = verify(
+          () => mockAPDataSource.cacheDevices(captureAny()),
+        ).captured.first as List<DeviceModelSealed>;
+
+        expect(captured.first.images, isNull);
+      });
+    });
+
+    group('room snapshot handling', () {
+      test('caches rooms from snapshot', () async {
+        when(() => mockRoomDataSource.cacheRooms(any()))
+            .thenAnswer((_) async {});
+
+        service.start();
+
+        messageController.add(SocketMessage(
+          type: 'message',
+          payload: {
+            'action': 'snapshot',
+            'resource_type': 'pms_rooms',
+            'data': [
+              {'id': 1, 'room': 'Room 101', 'floor': '1st'},
+              {'id': 2, 'room': 'Room 202', 'floor': '2nd'},
+            ],
+          },
+          headers: {'identifier': '{"channel":"RxgChannel"}'},
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verify(() => mockRoomDataSource.cacheRooms(any())).called(1);
+      });
+    });
+
+    group('syncInitialData', () {
+      test('returns true on successful sync', () async {
+        when(() => mockAPDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+        when(() => mockONTDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+        when(() => mockSwitchDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+        when(() => mockWLANDataSource.cacheDevices(any()))
+            .thenAnswer((_) async {});
+        when(() => mockRoomDataSource.cacheRooms(any()))
+            .thenAnswer((_) async {});
+
+        // Stub flushNow() for all device datasources
+        when(() => mockAPDataSource.flushNow())
+            .thenAnswer((_) async {});
+        when(() => mockONTDataSource.flushNow())
+            .thenAnswer((_) async {});
+        when(() => mockSwitchDataSource.flushNow())
+            .thenAnswer((_) async {});
+        when(() => mockWLANDataSource.flushNow())
+            .thenAnswer((_) async {});
+
+        // Stub storage for persisting ID-to-type index
+        when(() => mockStorageService.setString(any(), any()))
+            .thenAnswer((_) async => true);
+
+        // Start sync (non-blocking) and then send snapshot responses
+        final syncFuture = service.syncInitialData(
+          timeout: const Duration(seconds: 5),
+        );
+
+        // Simulate snapshot responses for all 5 resource types
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        for (final resourceType in [
+          'access_points',
+          'media_converters',
+          'switch_devices',
+          'wlan_devices',
+          'pms_rooms',
+        ]) {
+          messageController.add(SocketMessage(
+            type: 'message',
+            payload: {
+              'action': 'snapshot',
+              'resource_type': resourceType,
+              'data': <Map<String, dynamic>>[],
+            },
+            headers: {'identifier': '{"channel":"RxgChannel"}'},
+          ));
+        }
+
+        final result = await syncFuture;
+        expect(result, isTrue);
+      });
+    });
+  });
+}

--- a/test/core/services/websocket_service_test.dart
+++ b/test/core/services/websocket_service_test.dart
@@ -1,0 +1,604 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+import 'package:rgnets_fdk/core/services/websocket_service.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Creates a controllable fake WebSocket channel pair.
+///
+/// Returns the [WebSocketChannel] to inject into [WebSocketService] and a
+/// [StreamController] for simulating server messages.
+({WebSocketChannel channel, StreamController<dynamic> controller, List<dynamic> sent}) _createFakeChannel() {
+  final controller = StreamController<dynamic>.broadcast();
+  final sent = <dynamic>[];
+
+  final channel = _FakeChannel(
+    stream: controller.stream,
+    onSend: sent.add,
+  );
+
+  return (channel: channel, controller: controller, sent: sent);
+}
+
+/// Minimal WebSocketChannel fake that avoids implementing the full
+/// StreamChannelMixin interface by extending IOWebSocketChannel-style construction.
+class _FakeChannel implements WebSocketChannel {
+  _FakeChannel({
+    required Stream<dynamic> stream,
+    required this.onSend,
+  }) : _stream = stream;
+
+  final Stream<dynamic> _stream;
+  final void Function(dynamic) onSend;
+  int? _closeCode;
+  String? _closeReason;
+
+  @override
+  Stream<dynamic> get stream => _stream;
+
+  @override
+  WebSocketSink get sink => _FakeSink(onSend: onSend, onClose: (code, reason) {
+    _closeCode = code;
+    _closeReason = reason;
+  });
+
+  @override
+  int? get closeCode => _closeCode;
+
+  @override
+  String? get closeReason => _closeReason;
+
+  @override
+  String? get protocol => null;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeSink implements WebSocketSink {
+  _FakeSink({required this.onSend, required this.onClose});
+
+  final void Function(dynamic) onSend;
+  final void Function(int?, String?) onClose;
+  final _doneCompleter = Completer<void>();
+
+  @override
+  void add(dynamic data) => onSend(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<dynamic> addStream(Stream<dynamic> stream) async {
+    await for (final data in stream) {
+      add(data);
+    }
+  }
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    onClose(closeCode, closeReason);
+    if (!_doneCompleter.isCompleted) _doneCompleter.complete();
+  }
+
+  @override
+  Future<dynamic> get done => _doneCompleter.future;
+}
+
+WebSocketConfig _testConfig({
+  bool autoReconnect = false,
+  bool sendClientPing = false,
+}) {
+  return WebSocketConfig(
+    baseUri: Uri.parse('ws://localhost:9443/ws'),
+    autoReconnect: autoReconnect,
+    sendClientPing: sendClientPing,
+    initialReconnectDelay: const Duration(milliseconds: 10),
+    maxReconnectDelay: const Duration(milliseconds: 100),
+    heartbeatInterval: const Duration(seconds: 30),
+    heartbeatTimeout: const Duration(seconds: 45),
+  );
+}
+
+void main() {
+  late Logger logger;
+
+  setUp(() {
+    logger = Logger(level: Level.off);
+  });
+
+  group('WebSocketService', () {
+    group('initial state', () {
+      test('starts in disconnected state', () {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        expect(svc.currentState, SocketConnectionState.disconnected);
+        expect(svc.isConnected, isFalse);
+        expect(svc.lastMessage, isNull);
+
+        svc.dispose();
+        fake.controller.close();
+      });
+    });
+
+    group('connect', () {
+      test('transitions to connected state', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        expect(svc.isConnected, isTrue);
+        expect(svc.currentState, SocketConnectionState.connected);
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('sends handshake message if provided', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(
+            uri: Uri.parse('ws://localhost/ws'),
+            handshakeMessage: {'type': 'hello'},
+          ),
+        );
+
+        expect(fake.sent, hasLength(1));
+        final decoded =
+            jsonDecode(fake.sent.first as String) as Map<String, dynamic>;
+        expect(decoded['type'], 'hello');
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+    });
+
+    group('disconnect', () {
+      test('transitions to disconnected state', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+        expect(svc.isConnected, isTrue);
+
+        await svc.disconnect(code: 1000, reason: 'test');
+
+        expect(svc.isConnected, isFalse);
+        expect(svc.currentState, SocketConnectionState.disconnected);
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+    });
+
+    group('send', () {
+      test('sends JSON-encoded message', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        svc.send({'command': 'subscribe', 'identifier': '{"channel":"Test"}'});
+
+        expect(fake.sent, hasLength(1));
+        final decoded =
+            jsonDecode(fake.sent.first as String) as Map<String, dynamic>;
+        expect(decoded['command'], 'subscribe');
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('throws StateError when not connected', () {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        expect(
+          () => svc.send({'type': 'test'}),
+          throwsA(isA<StateError>()),
+        );
+
+        svc.dispose();
+        fake.controller.close();
+      });
+    });
+
+    group('message parsing', () {
+      test('parses ActionCable confirm_subscription', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        final messages = <SocketMessage>[];
+        svc.messages.listen(messages.add);
+
+        fake.controller.add(jsonEncode({
+          'type': 'confirm_subscription',
+          'identifier': '{"channel":"RxgChannel"}',
+        }));
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(messages, hasLength(1));
+        expect(messages.first.type, 'confirm_subscription');
+        expect(
+            messages.first.headers?['identifier'], '{"channel":"RxgChannel"}');
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('parses message with payload', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        final messages = <SocketMessage>[];
+        svc.messages.listen(messages.add);
+
+        fake.controller.add(jsonEncode({
+          'type': 'data.snapshot',
+          'payload': {'items': [1, 2, 3]},
+        }));
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(messages, hasLength(1));
+        expect(messages.first.type, 'data.snapshot');
+        expect(messages.first.payload['items'], [1, 2, 3]);
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('parses ActionCable message with nested message field', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        final messages = <SocketMessage>[];
+        svc.messages.listen(messages.add);
+
+        fake.controller.add(jsonEncode({
+          'identifier': '{"channel":"RxgChannel"}',
+          'message': {'action': 'snapshot', 'data': [1, 2]},
+        }));
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(messages, hasLength(1));
+        expect(messages.first.type, 'snapshot');
+        expect(messages.first.payload['data'], [1, 2]);
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('defaults type to "message" when no type found', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        final messages = <SocketMessage>[];
+        svc.messages.listen(messages.add);
+
+        fake.controller.add(jsonEncode({'data': 'raw'}));
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(messages, hasLength(1));
+        expect(messages.first.type, 'message');
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('updates lastMessage', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        fake.controller.add(jsonEncode({'type': 'ping'}));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(svc.lastMessage, isNotNull);
+        expect(svc.lastMessage!.type, 'ping');
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+    });
+
+    group('pending requests', () {
+      test('request correlates response by request_id', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        final responseFuture = svc.request(
+          {'command': 'message', 'request_id': 'test-123'},
+          timeout: const Duration(seconds: 5),
+        );
+
+        // Simulate server response with matching request_id
+        fake.controller.add(jsonEncode({
+          'type': 'response',
+          'request_id': 'test-123',
+          'payload': {'status': 'ok'},
+        }));
+
+        final response = await responseFuture;
+        expect(response.type, 'response');
+        expect(response.payload['status'], 'ok');
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('request times out with TimeoutException', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        expect(
+          svc.request(
+            {'command': 'message', 'request_id': 'timeout-test'},
+            timeout: const Duration(milliseconds: 50),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+
+        // Wait for timeout to fire
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('disconnect fails pending requests', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        // Start request but don't await - capture the future
+        Object? caughtError;
+        final responseFuture = svc.request(
+          {'command': 'message', 'request_id': 'disconnect-test'},
+          timeout: const Duration(seconds: 5),
+        ).catchError((Object e) {
+          caughtError = e;
+          return const SocketMessage(type: 'error', payload: {});
+        });
+
+        await svc.disconnect();
+        await responseFuture;
+
+        expect(caughtError, isA<StateError>());
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+    });
+
+    group('connection state stream', () {
+      test('emits connected then disconnected', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        // Subscribe before connecting to capture all states
+        final states = <SocketConnectionState>[];
+        svc.connectionState.listen(states.add);
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        // Give stream time to emit
+        await Future<void>.delayed(Duration.zero);
+
+        expect(states, contains(SocketConnectionState.connecting));
+        expect(states, contains(SocketConnectionState.connected));
+
+        await svc.disconnect();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(states, contains(SocketConnectionState.disconnected));
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+
+      test('does not emit duplicate states', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        final states = <SocketConnectionState>[];
+        svc.connectionState.listen(states.add);
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+        await svc.disconnect();
+        await Future<void>.delayed(Duration.zero);
+        final countBefore = states.length;
+
+        await svc.disconnect(); // second disconnect should not emit
+        await Future<void>.delayed(Duration.zero);
+
+        expect(states.length, countBefore);
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+    });
+
+    group('sendType', () {
+      test('composes envelope with type and payload', () async {
+        final fake = _createFakeChannel();
+        final svc = WebSocketService(
+          config: _testConfig(),
+          logger: logger,
+          channelFactory: (uri, {headers}) => fake.channel,
+        );
+
+        await svc.connect(
+          WebSocketConnectionParams(uri: Uri.parse('ws://localhost/ws')),
+        );
+
+        svc.sendType('system.ping', payload: {'ts': '2024'});
+
+        expect(fake.sent, hasLength(1));
+        final decoded =
+            jsonDecode(fake.sent.first as String) as Map<String, dynamic>;
+        expect(decoded['type'], 'system.ping');
+        expect(decoded['payload']['ts'], '2024');
+
+        await svc.dispose();
+        await fake.controller.close();
+      });
+    });
+
+    group('WebSocketConfig', () {
+      test('has correct defaults', () {
+        final config = WebSocketConfig(
+          baseUri: Uri.parse('ws://test'),
+        );
+        expect(config.autoReconnect, isTrue);
+        expect(config.sendClientPing, isTrue);
+        expect(config.initialReconnectDelay, const Duration(seconds: 1));
+        expect(config.maxReconnectDelay, const Duration(seconds: 32));
+      });
+    });
+
+    group('WebSocketConnectionParams', () {
+      test('stores uri and optional fields', () {
+        final params = WebSocketConnectionParams(
+          uri: Uri.parse('ws://test'),
+          headers: {'Authorization': 'Bearer token'},
+          handshakeMessage: {'type': 'hello'},
+        );
+        expect(params.uri.toString(), 'ws://test');
+        expect(params.headers?['Authorization'], 'Bearer token');
+        expect(params.handshakeMessage?['type'], 'hello');
+      });
+    });
+
+    group('SocketMessage', () {
+      test('stores all fields', () {
+        const msg = SocketMessage(
+          type: 'test',
+          payload: {'key': 'value'},
+          headers: {'id': 'abc'},
+          raw: {'type': 'test', 'key': 'value'},
+        );
+        expect(msg.type, 'test');
+        expect(msg.payload['key'], 'value');
+        expect(msg.headers?['id'], 'abc');
+        expect(msg.raw?['type'], 'test');
+      });
+    });
+  });
+}

--- a/test/features/auth/presentation/providers/auth_notifier_credential_recovery_test.dart
+++ b/test/features/auth/presentation/providers/auth_notifier_credential_recovery_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fpdart/fpdart.dart';
@@ -13,7 +11,6 @@ import 'package:rgnets_fdk/features/auth/domain/entities/auth_status.dart';
 import 'package:rgnets_fdk/features/auth/domain/entities/user.dart';
 import 'package:rgnets_fdk/features/auth/domain/repositories/auth_repository.dart';
 import 'package:rgnets_fdk/features/auth/presentation/providers/auth_notifier.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 // Mocks
 class MockAuthRepository extends Mock implements AuthRepository {}
@@ -34,9 +31,19 @@ void main() {
     mockStorageService = MockStorageService();
     mockLogger = MockLogger();
 
-    // Setup default mock behavior
-    when(() => mockStorageService.migrateLegacyCredentialsIfNeeded())
+    // Setup default mock behavior for StorageService
+    when(() => mockStorageService.migrateToSecureStorageIfNeeded())
         .thenAnswer((_) async {});
+    when(() => mockStorageService.getToken())
+        .thenAnswer((_) async => null);
+    when(() => mockStorageService.getAuthSignature())
+        .thenAnswer((_) async => null);
+    when(() => mockStorageService.token).thenReturn(null);
+    when(() => mockStorageService.siteUrl).thenReturn(null);
+    when(() => mockStorageService.username).thenReturn(null);
+    when(() => mockStorageService.siteName).thenReturn(null);
+    when(() => mockStorageService.authIssuedAt).thenReturn(null);
+    when(() => mockStorageService.authSignature).thenReturn(null);
     when(() => mockLogger.i(any())).thenReturn(null);
     when(() => mockLogger.d(any())).thenReturn(null);
     when(() => mockLogger.w(any())).thenReturn(null);
@@ -54,6 +61,8 @@ void main() {
 
         // Credentials exist in storage
         when(() => mockStorageService.token).thenReturn('valid-token');
+        when(() => mockStorageService.getToken())
+            .thenAnswer((_) async => 'valid-token');
         when(() => mockStorageService.siteUrl)
             .thenReturn('https://test.rgnets.com');
         when(() => mockStorageService.username).thenReturn('testuser');
@@ -61,16 +70,12 @@ void main() {
         when(() => mockStorageService.authIssuedAt).thenReturn(null);
         when(() => mockStorageService.authSignature).thenReturn(null);
 
-        // Setup SharedPreferences for the container
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-
         // Create provider container with overrides
         final container = ProviderContainer(
           overrides: [
             authRepositoryProvider.overrideWithValue(mockAuthRepository),
             storageServiceProvider
-                .overrideWithValue(StorageService(prefs)),
+                .overrideWithValue(mockStorageService),
             loggerProvider.overrideWithValue(mockLogger),
           ],
         );
@@ -107,13 +112,10 @@ void main() {
         when(() => mockStorageService.siteUrl).thenReturn(null);
         when(() => mockStorageService.username).thenReturn(null);
 
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-
         final container = ProviderContainer(
           overrides: [
             authRepositoryProvider.overrideWithValue(mockAuthRepository),
-            storageServiceProvider.overrideWithValue(StorageService(prefs)),
+            storageServiceProvider.overrideWithValue(mockStorageService),
             loggerProvider.overrideWithValue(mockLogger),
           ],
         );
@@ -136,13 +138,10 @@ void main() {
         when(() => mockStorageService.siteUrl).thenReturn('');
         when(() => mockStorageService.username).thenReturn('');
 
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-
         final container = ProviderContainer(
           overrides: [
             authRepositoryProvider.overrideWithValue(mockAuthRepository),
-            storageServiceProvider.overrideWithValue(StorageService(prefs)),
+            storageServiceProvider.overrideWithValue(mockStorageService),
             loggerProvider.overrideWithValue(mockLogger),
           ],
         );
@@ -171,13 +170,10 @@ void main() {
         // recovery to ensure WebSocket is connected. Without credentials in
         // storage, this will return unauthenticated. In production, credentials
         // should always exist when user model exists.
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-
         final container = ProviderContainer(
           overrides: [
             authRepositoryProvider.overrideWithValue(mockAuthRepository),
-            storageServiceProvider.overrideWithValue(StorageService(prefs)),
+            storageServiceProvider.overrideWithValue(mockStorageService),
             loggerProvider.overrideWithValue(mockLogger),
           ],
         );
@@ -206,6 +202,8 @@ void main() {
 
         // But credentials exist
         when(() => mockStorageService.token).thenReturn('valid-token');
+        when(() => mockStorageService.getToken())
+            .thenAnswer((_) async => 'valid-token');
         when(() => mockStorageService.siteUrl)
             .thenReturn('https://test.rgnets.com');
         when(() => mockStorageService.username).thenReturn('testuser');
@@ -213,13 +211,10 @@ void main() {
         when(() => mockStorageService.authIssuedAt).thenReturn(null);
         when(() => mockStorageService.authSignature).thenReturn(null);
 
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-
         final container = ProviderContainer(
           overrides: [
             authRepositoryProvider.overrideWithValue(mockAuthRepository),
-            storageServiceProvider.overrideWithValue(StorageService(prefs)),
+            storageServiceProvider.overrideWithValue(mockStorageService),
             loggerProvider.overrideWithValue(mockLogger),
           ],
         );

--- a/test/features/initialization/presentation/providers/initialization_provider_test.dart
+++ b/test/features/initialization/presentation/providers/initialization_provider_test.dart
@@ -33,7 +33,7 @@ void main() {
       () => mockDataSyncService.syncInitialData(
         timeout: any(named: 'timeout'),
       ),
-    ).thenAnswer((_) async {});
+    ).thenAnswer((_) async => true);
     when(() => mockDataSyncService.events).thenAnswer(
       (_) => eventsController.stream,
     );
@@ -185,6 +185,7 @@ void main() {
       ).thenAnswer((_) async {
         callCount++;
         await Future<void>.delayed(const Duration(milliseconds: 100));
+        return true;
       });
 
       final notifier =
@@ -237,6 +238,7 @@ void main() {
         ),
       ).thenAnswer((_) async {
         await Future<void>.delayed(const Duration(milliseconds: 100));
+        return true;
       });
 
       // Start initialization and wait for it in the test
@@ -352,9 +354,10 @@ void main() {
         () => mockDataSyncService.syncInitialData(
           timeout: any(named: 'timeout'),
         ),
-      ).thenAnswer(
-        (_) async => Future<void>.delayed(const Duration(milliseconds: 50)),
-      );
+      ).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        return true;
+      });
 
       await container
           .read(initializationNotifierProvider.notifier)
@@ -395,9 +398,10 @@ void main() {
         () => mockDataSyncService.syncInitialData(
           timeout: any(named: 'timeout'),
         ),
-      ).thenAnswer(
-        (_) async => Future<void>.delayed(const Duration(milliseconds: 800)),
-      );
+      ).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 800));
+        return true;
+      });
 
       final notifier =
           container.read(initializationNotifierProvider.notifier);
@@ -425,9 +429,10 @@ void main() {
         () => mockDataSyncService.syncInitialData(
           timeout: any(named: 'timeout'),
         ),
-      ).thenAnswer(
-        (_) async => Future<void>.delayed(const Duration(milliseconds: 600)),
-      );
+      ).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(milliseconds: 600));
+        return true;
+      });
 
       final notifier =
           container.read(initializationNotifierProvider.notifier);


### PR DESCRIPTION
## Summary

- **Security**: Fixed certificate validator (C1), redacted API tokens from logs (S1), documented API key baking risk (M7)
- **Testing**: Added 49 new unit tests for WebSocketService, WebSocketDataSyncService, and CertificateValidator (C2)
- **Architecture**: Extracted ActionCable handshake into dedicated service reducing 165→65 lines (M8), documented core→features dependency (M1)
- **Reliability**: Fixed timeout reporting (M2), reconnect concurrency (M3), disconnect cleanup (M4), heartbeat guard (M5), cache error handling (M6), room cache race condition (M9)
- **Code quality**: Proper test mocks (L1), UUID for request IDs (L2), web platform header warning (L4), REST config documentation (M10)

## Test plan

- [x] All 49 new unit tests pass (20 WebSocketService + 14 WebSocketDataSyncService + 15 CertificateValidator)
- [x] Full test suite: 944 pass, 9 fail (all pre-existing, 0 regressions)
- [ ] Manual smoke test: login, WebSocket connection, device sync
- [ ] Verify certificate behavior on staging (reject invalid certs in release mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)